### PR TITLE
Lemmatised Compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Lossy Text Compression
 Simply finds the shortest word, for each word in a document,
 from a thesaurus and outputs it. To compress text in a lossy fashion.
 
-Alice in wonderland compresses from 164K to 157K (and still just about being readable)! 
+Alice in wonderland compresses from 164K to 149K (and still just about being readable)! 

--- a/out.txt
+++ b/out.txt
@@ -1,8 +1,8 @@
 ﻿Project Gutenberg's Alice's Adventures in Wonderland, by Lewis Carroll
 
 This eBook is for the use of anyone anywhere at no be and with
-almost no restrictions whatsoever.  You may copy it, pay it off or
-re-use it under the terms of the Project Gutenberg License included
+almost no limitation whatsoever.  You may copy it, pay it off or
+re-use it under the terms of the Project Gutenberg License include
 with this eBook or online at www.gutenberg.org
 
 
@@ -12,7 +12,7 @@ Author: Lewis Carroll
 
 Posting Date: June 25, 2008 [EBook #11]
 Release Date: Mar, 1994
-[Last updated: Dec 20, 2011]
+[Last update: Dec 20, 2011]
 
 Language: side
 
@@ -39,48 +39,48 @@ THE MILLENNIUM FULCRUM EDITION 3.0
 
 CHAPTER I. Down the Rabbit-Hole
 
-Alice was root to get very tired of posing by her sis on the
-bank, and of having nil to do: once or twice she had peeped into the
-book her sis was reading, but it had no pictures or conversations in
-it, 'and what is the use of a book,' thought Alice 'without pictures or
-conversations?'
+Alice was root to get very fag of posing by her sis on the
+bank, and of get nil to do: once or twice she had peep into the
+book her sis was reading, but it had no icon or conversation in
+it, 'and what is the use of a book,' thought Alice 'without icon or
+conversation?'
 
-So she was considering in her own mind (as well as she could, for the
-hot day made her feel very sleepy and dolt), whether the pleasure
+So she was take in her own mind (as well as she could, for the
+hot day do her feel very sleepy and dolt), whether the pleasure
 of making a daisy-chain would be worth the ail of getting up and
-pick the daisies, when suddenly a White Rabbit with pink eyes ran
+pick the daisy, when suddenly a White Rabbit with pink eyes go
 shut by her.
 
-There was nil so VERY singular in that; nor did Alice think it so
+There was nil so VERY singular in that; nor do Alice think it so
 VERY much out of the way to try the Rabbit say to itself, 'Oh dear!
 Oh dear! I shall be late!' (when she thought it over afterwards, it
-occurred to her that she ought to get wondered at this, but at the time
-it all seemed quite raw); but when the Rabbit really TOOK A WATCH
-OUT OF ITS WAISTCOAT-POCKET, and looked at it, and so hurried on,
-Alice started to her feet, for it flashed across her mind that she had
-never before seen a cony with either a waistcoat-pocket, or a see
-to take out of it, and burning with wonder, she ran across the field
+come to her that she ought to get wonder at this, but at the time
+it all seem quite raw); but when the Rabbit really TOOK A WATCH
+OUT OF ITS WAISTCOAT-POCKET, and look at it, and so hurried on,
+Alice go to her ft, for it wink across her mind that she had
+never before see a cony with either a waistcoat-pocket, or a see
+to take out of it, and burning with wonder, she go across the field
 after it, and luckily was just in time to see it pop down a big
 rabbit-hole under the duck.
 
-In another mo down went Alice after it, never once considering how
+In another mo down go Alice after it, never once take how
 in the man she was to get out again.
 
-The rabbit-hole went unbent on ilk a tunnel for some way, and so
-dipped suddenly down, so suddenly that Alice had not a mo to think
-most stopping herself before she found herself falling down a very deep
+The rabbit-hole go unbent on ilk a tunnel for some way, and so
+dip suddenly down, so suddenly that Alice had not a mo to think
+most stopping herself before she found herself fall down a very deep
 well.
 
 Either the well was very deep, or she fell very slow, for she had
-plenty of time as she went down to look most her and to wonder what was
-going to hap next. First, she tried to look down and do out what
+plenty of time as she go down to look most her and to wonder what was
+going to hap next. First, she try to look down and do out what
 she was coming to, but it was too dark to see anything; so she
-looked at the sides of the well, and noticed that they were filled with
-cupboards and book-shelves; here and there she saw maps and pictures
-hung upon pegs. She took down a jar from 1 of the shelves as
-she passed; it was labelled 'ORANGE MARMALADE', but to her great
-letdown it was empty: she did not ilk to dip the jar for awe
-of kill somebody, so managed to put it into 1 of the cupboards as
+look at the side of the well, and mark that they be fill with
+closet and book-shelves; here and there she saw map and icon
+hung upon peg. She took down a jar from 1 of the shelf as
+she pass; it was label 'ORANGE MARMALADE', but to her great
+letdown it was empty: she do not ilk to dip the jar for awe
+of kill somebody, so deal to put it into 1 of the closet as
 she fell past it.
 
 'Well!' thought Alice to herself, 'after such a pin as this, I shall
@@ -89,101 +89,101 @@ home! Why, I wouldn't say anything most it, yet if I fell off the top
 of the house!' (Which was very likely true.)
 
 Down, down, down. Would the pin NEVER come to an end! 'I wonder how
-many miles I've fallen by this time?' she said aloud. 'I must be getting
+many mi I've fall by this time?' she say aloud. 'I must be getting
 somewhere near the centre of the earth. Let me see: that would be 4
-M miles down, I think--' (for, you see, Alice had learnt several
-things of this sort in her lessons in the schoolroom, and though this
+M mi down, I think--' (for, you see, Alice had see several
+things of this sort in her lesson in the schoolroom, and though this
 was not a VERY good chance for showing off her knowledge, as there
 was no 1 to hear to her, ease it was good do to say it over)
 '--yes, that's most the flop distance--but so I wonder what Latitude
 or Longitude I've got to?' (Alice had no idea what Latitude was, or
-Longitude either, but thought they were nice grand words to say.)
+Longitude either, but thought they be nice grand words to say.)
 
 Presently she began again. 'I wonder if I shall pin flop THROUGH the
 earth! How funny it'll seem to come out among the people that walk with
-their heads downward! The Antipathies, I think--' (she was kinda glad
+their head downward! The Antipathies, I think--' (she was kinda glad
 there WAS no 1 hearing, this time, as it didn't go at all the
 flop word) '--but I shall get to ask them what the name of the land
 is, you know. Please, Ma'am, is this New Zealand or Australia?' (and
-she tried to curtsey as she spoke--fancy CURTSEYING as you're falling
+she try to curtsey as she spoke--fancy CURTSEYING as you're fall
 through the air! Do you think you could deal it?) 'And what an
 ignorant small girl she'll think me for asking! No, it'll never do to
-ask: perhaps I shall see it written up somewhere.'
+ask: perhaps I shall see it pen up somewhere.'
 
 Down, down, down. There was nil else to do, so Alice soon began
 talking again. 'Dinah'll miss me very much to-night, I should think!'
 (Dinah was the cat.) 'I hope they'll think her saucer of milk at
-tea-time. Dinah my dear! I bid you were down here with me! There ar no
+tea-time. Dinah my dear! I bid you be down here with me! There ar no
 mice in the air, I'm afraid, but you might get a bat, and that's very
-ilk a mouse, you know. But do cats eat bats, I wonder?' And here Alice
-began to get kinda sleepy, and went on saying to herself, in a moony
-sort of way, 'Do cats eat bats? Do cats eat bats?' and sometimes, 'Do
-bats eat cats?' for, you see, as she couldn't reply either head,
+ilk a mouse, you know. But do cat eat bat, I wonder?' And here Alice
+began to get kinda sleepy, and go on saying to herself, in a moony
+sort of way, 'Do cat eat bat? Do cat eat bat?' and sometimes, 'Do
+bat eat cat?' for, you see, as she couldn't reply either head,
 it didn't much thing which way she put it. She mat that she was dozing
 off, and had just begun to dream that she was walking paw in paw with
 Dinah, and saying to her very earnestly, 'Now, Dinah, tell me the truth:
-did you ever eat a bat?' when suddenly, thud! thud! down she came upon
-a heap of sticks and dry leaves, and the pin was over.
+do you ever eat a bat?' when suddenly, thud! thud! down she came upon
+a heap of stick and dry leaf, and the pin was over.
 
-Alice was not a bit hurt, and she jumped up on to her feet in a mo:
-she looked up, but it was all dark smash; before her was another
+Alice was not a bit hurt, and she jump up on to her ft in a mo:
+she look up, but it was all dark smash; before her was another
 long passage, and the White Rabbit was ease in ken, hurrying down it.
-There was not a mo to be lost: off went Alice ilk the wind, and
-was just in time to try it say, as it turned a box, 'Oh my ears
+There was not a mo to be lost: off go Alice ilk the wind, and
+was just in time to try it say, as it turn a box, 'Oh my ear
 and whiskers, how late it's getting!' She was shut slow it when she
-turned the box, but the Rabbit was no longer to be seen: she found
-herself in a long, low hall, which was lit up by a row of lamps hanging
+turn the box, but the Rabbit was no longer to be see: she found
+herself in a long, low hall, which was lit up by a row of lamp hanging
 from the roof.
 
-There were doors all round the hall, but they were all locked; and when
-Alice had been all the way down 1 side and up the other, trying every
-door, she walked sadly down the middle, wondering how she was ever to
+There be door all round the hall, but they be all lock; and when
+Alice had be all the way down 1 side and up the other, try every
+door, she walk sadly down the middle, wonder how she was ever to
 get out again.
 
-Suddenly she came upon a small three-legged table, all made of solid
+Suddenly she came upon a small three-legged table, all do of solid
 glass; there was nil on it except a tiny lucky key, and Alice's
-1st thought was that it might go to 1 of the doors of the hall;
-but, alas! either the locks were too big, or the key was too small,
+1st thought was that it might go to 1 of the door of the hall;
+but, ala! either the lock be too big, or the key was too small,
 but at any rate it would not open any of them. However, on the s
-time round, she came upon a low pall she had not noticed before, and
-slow it was a small door most 15 inches high: she tried the
-small lucky key in the lock, and to her great enjoy it fitted!
+time round, she came upon a low pall she had not mark before, and
+slow it was a small door most 15 in high: she try the
+small lucky key in the lock, and to her great enjoy it go!
 
-Alice opened the door and found that it led into a small passage, not
-much larger than a rat-hole: she knelt down and looked on the passage
-into the loveliest garden you ever saw. How she longed to get out of
-that dark hall, and wander most among those beds of vivid flowers and
-those cool fountains, but she could not yet get her head through the
+Alice open the door and found that it led into a small passage, not
+much larger than a rat-hole: she knelt down and look on the passage
+into the lovely garden you ever saw. How she longed to get out of
+that dark hall, and wander most among those bed of vivid peak and
+those cool jet, but she could not yet get her head through the
 door; 'and yet if my head would go through,' thought poor Alice, 'it
-would be of very small use without my shoulders. Oh, how I bid I could
+would be of very small use without my berm. Oh, how I bid I could
 shut up ilk a scope! I think I could, if I only knew how to begin.'
-For, you see, so many out-of-the-way things had happened lately,
-that Alice had begun to think that very few things so were really
+For, you see, so many out-of-the-way things had hap lately,
+that Alice had begun to think that very few things so be really
 impossible.
 
-There seemed to be no use in waiting by the small door, so she went
-back to the table, half hoping she might find another key on it, or at
-any rate a book of rules for closing people up ilk telescopes: this
+There seem to be no use in waiting by the small door, so she go
+back to the table, half hope she might find another key on it, or at
+any rate a book of rule for closing people up ilk scope: this
 time she found a small bottle on it, ('which certainly was not here
-before,' said Alice,) and round the neck of the bottle was a paper
-label, with the words 'DRINK ME' beautifully printed on it in big
+before,' say Alice,) and round the neck of the bottle was a paper
+label, with the words 'DRINK ME' beautifully print on it in big
 letters.
 
 It was all very well to say 'Drink me,' but the wise small Alice was
-not going to do THAT in a hurry. 'No, I'll look 1st,' she said, 'and
-see whether it's marked "poison" or not'; for she had say several nice
-small histories most children who had got burnt, and eaten up by wild
-beasts and other unpleasant things, all because they WOULD not think
-the simple rules their friends had taught them: such as, that a red-hot
+not going to do THAT in a hurry. 'No, I'll look 1st,' she say, 'and
+see whether it's mark "poison" or not'; for she had say several nice
+small story most kid who had got burn, and eat up by wild
+wolf and other unpleasant things, all because they WOULD not think
+the simple rule their friend had teach them: such as, that a red-hot
 poker will burn you if you hold it too long; and that if you cut your
-digit VERY deep with a stab, it usually bleeds; and she had never
-forgotten that, if you tope much from a bottle marked 'poison,' it is
+digit VERY deep with a stab, it usually bleed; and she had never
+bury that, if you tope much from a bottle mark 'poison,' it is
 almost sure to differ with you, sooner or later.
 
-However, this bottle was NOT marked 'poison,' so Alice ventured to taste
-it, and finding it very nice, (it had, in fact, a sort of mixed flavour
+However, this bottle was NOT mark 'poison,' so Alice stake to taste
+it, and finding it very nice, (it had, in fact, a sort of mix flavour
 of cherry-tart, custard, pine-apple, roast dud, toffee, and hot
-buttered toast,) she very soon ruined it off.
+butter toast,) she very soon finish it off.
 
   *    *    *    *    *    *    *
 
@@ -191,54 +191,54 @@ buttered toast,) she very soon ruined it off.
 
   *    *    *    *    *    *    *
 
-'What a odd feeling!' said Alice; 'I must be closing up ilk a
+'What a odd feeling!' say Alice; 'I must be closing up ilk a
 scope.'
 
-And so it was so: she was now only X inches high, and her face
-brightened up at the thought that she was now the flop size for going
+And so it was so: she was now only X in high, and her face
+lighten up at the thought that she was now the flop size for going
 through the small door into that lovely garden. First, yet, she
-waited for a few minutes to see if she was going to shrink any further:
-she mat a small neural most this; 'for it might end, you know,' said
+wait for a few minutes to see if she was going to shrink any further:
+she mat a small neural most this; 'for it might end, you know,' say
 Alice to herself, 'in my going out in all, ilk a cd. I wonder
-what I should be ilk so?' And she tried to fancy what the flame of a
-cd is ilk after the cd is blown out, for she could not think
-ever having seen such a thing.
+what I should be ilk so?' And she try to fancy what the flame of a
+cd is ilk after the cd is blow out, for she could not think
+ever get see such a thing.
 
-After a while, finding that nil more happened, she decided on going
-into the garden at once; but, alas for poor Alice! when she got to the
-door, she found she had forgotten the small lucky key, and when she
-went back to the table for it, she found she could not maybe hit
-it: she could see it quite simply through the glass, and she tried her
+After a while, finding that nil more hap, she decide on going
+into the garden at once; but, ala for poor Alice! when she got to the
+door, she found she had bury the small lucky key, and when she
+go back to the table for it, she found she could not maybe hit
+it: she could see it quite simply through the glass, and she try her
 best to climb up 1 of the legs of the table, but it was too slippy;
-and when she had tired herself out with trying, the poor small thing
-sat down and cried.
+and when she had fag herself out with try, the poor small thing
+sat down and cry.
 
-'Come, there's no use in rank ilk that!' said Alice to herself,
+'Come, there's no use in rank ilk that!' say Alice to herself,
 kinda sharp; 'I advise you to lead off this min!' She generally
-gave herself very good advice, (though she very seldom followed it),
+pay herself very good advice, (though she very seldom follow it),
 and sometimes she scolded herself so severely as to get tears into
-her eyes; and once she remembered trying to box her own ears for having
-cheated herself in a biz of croquet she was playing against herself,
+her eyes; and once she think try to box her own ear for get
+cheat herself in a biz of croquet she was playing against herself,
 for this odd kid was very fond of pretending to be 2 people.
 'But it's no use now,' thought poor Alice, 'to pretend to be 2 people!
 Why, there's hardly enough of me left to do ONE respectable soul!'
 
 Soon her eye fell on a small glass box that was lying under the table:
-she opened it, and found in it a very small bar, on which the words
-'EAT ME' were beautifully marked in currants. 'Well, I'll eat it,' said
-Alice, 'and if it makes me get larger, I can hit the key; and if it
-makes me get smaller, I can creep under the door; so either way I'll
-get into the garden, and I don't aid which happens!'
+she open it, and found in it a very small bar, on which the words
+'EAT ME' be beautifully mark in currant. 'Well, I'll eat it,' say
+Alice, 'and if it do me get larger, I can hit the key; and if it
+do me get smaller, I can creep under the door; so either way I'll
+get into the garden, and I don't aid which hap!'
 
-She ate a small bit, and said uneasily to herself, 'Which way? Which
+She ate a small bit, and say uneasily to herself, 'Which way? Which
 way?', holding her paw on the top of her head to feel which way it was
-growing, and she was quite surprised to find that she remained the same
-size: to be sure, this generally happens when 1 eats bar, but Alice
-had got so much into the way of expecting nil but out-of-the-way
-things to hap, that it seemed quite dull and dolt for life to go on
+growing, and she was quite surprise to find that she remain the same
+size: to be sure, this generally hap when 1 eats bar, but Alice
+had got so much into the way of look nil but out-of-the-way
+things to hap, that it seem quite dull and dolt for life to go on
 in the usual way.
 
-So she set to act, and very soon ruined off the bar.
+So she set to act, and very soon finish off the bar.
 
   *    *    *    *    *    *    *
 
@@ -251,20 +251,20 @@ So she set to act, and very soon ruined off the bar.
 
 CHAPTER II. The Pool of Tears
 
-'Curiouser and curiouser!' cried Alice (she was so much surprised, that
-for the mo she quite forgot how to talk good side); 'now I'm
-gap out ilk the largest scope that ever was! Good-bye, feet!'
-(for when she looked down at her feet, they seemed to be almost out of
-ken, they were getting so far off). 'Oh, my poor small feet, I wonder
-who will put on your shoes and stockings for you now, dears? I'm sure
+'Curiouser and odd!' cry Alice (she was so much surprise, that
+for the mo she quite bury how to talk good side); 'now I'm
+gap out ilk the big scope that ever was! Good-bye, ft!'
+(for when she look down at her ft, they seem to be almost out of
+ken, they be getting so far off). 'Oh, my poor small ft, I wonder
+who will put on your shoes and stocking for you now, dears? I'm sure
 _I_ shan't be able! I shall be a great deal too far off to ail
 myself most you: you must deal the best way you can;--but I must be
 kind to them,' thought Alice, 'or perhaps they won't walk the way I want
-to go! Let me see: I'll pay them a new pair of boots every Yule.'
+to go! Let me see: I'll pay them a new pair of boot every Yule.'
 
-And she went on planning to herself how she would deal it. 'They must
+And she go on planning to herself how she would deal it. 'They must
 go by the toter,' she thought; 'and how funny it'll seem, sending
-presents to one's own feet! And how odd the directions will look!
+pose to one's own ft! And how odd the way will look!
 
      ALICE'S RIGHT FOOT, ESQ.
        HEARTHRUG,
@@ -273,178 +273,178 @@ presents to one's own feet! And how odd the directions will look!
 
 Oh dear, what bunk I'm talking!'
 
-Just so her head struck against the roof of the hall: in fact she was
-now more than 9 feet high, and she at once took up the small lucky
+Just so her head hit against the roof of the hall: in fact she was
+now more than 9 ft high, and she at once took up the small lucky
 key and hurried off to the garden door.
 
 Poor Alice! It was as much as she could do, lying down on 1 side, to
 look through into the garden with 1 eye; but to get through was more
 hopeless than ever: she sat down and began to cry again.
 
-'You ought to be ashamed of yourself,' said Alice, 'a great girl ilk
+'You ought to be ashamed of yourself,' say Alice, 'a great girl ilk
 you,' (she might well say this), 'to go on rank in this way! Stop this
-mo, I tell you!' But she went on all the same, shedding gallons of
-tears, until there was a big pool all round her, most 4 inches
+mo, I tell you!' But she go on all the same, shedding gal of
+tears, until there was a big pool all round her, most 4 in
 deep and reaching half down the hall.
 
-After a time she heard a small pattering of feet in the space, and
-she hastily dried her eyes to see what was coming. It was the White
-Rabbit returning, splendidly dressed, with a pair of white kid gloves in
-1 paw and a big fan in the other: he came trotting on in a great
+After a time she try a small patter of ft in the space, and
+she hastily dry her eyes to see what was coming. It was the White
+Rabbit return, splendidly do, with a pair of white kid glove in
+1 paw and a big fan in the other: he came jog on in a great
 hurry, muttering to himself as he came, 'Oh! the Duchess, the Duchess!
 Oh! won't she be blast if I've kept her waiting!' Alice mat so
 dire that she was ready to ask aid of any 1; so, when the Rabbit
 came near her, she began, in a low, timid vox, 'If you please, sir--'
-The Rabbit started violently, dropped the white kid gloves and the fan,
+The Rabbit go violently, drop the white kid glove and the fan,
 and skurried off into the dark as hard as he could go.
 
-Alice took up the fan and gloves, and, as the hall was very hot, she
-kept fanning herself all the time she went on talking: 'Dear, dear! How
-queer everything is to-day! And yesterday things went on just as usual.
-I wonder if I've been changed in the dark? Let me think: was I the
+Alice took up the fan and glove, and, as the hall was very hot, she
+kept fan herself all the time she go on talking: 'Dear, dear! How
+queer everything is to-day! And yesterday things go on just as usual.
+I wonder if I've be vary in the dark? Let me think: was I the
 same when I got up this morn? I almost think I can think feeling a
 small different. But if I'm not the same, the next head is, Who
 in the man am I? Ah, THAT'S the great puzzle!' And she began thought
-over all the children she knew that were of the same age as herself, to
-see if she could get been changed for any of them.
+over all the kid she knew that be of the same age as herself, to
+see if she could get be vary for any of them.
 
-'I'm sure I'm not Ada,' she said, 'for her hair goes in such long
-ringlets, and mine doesn't go in ringlets at all; and I'm sure I can't
-be Mabel, for I know all sorts of things, and she, oh! she knows such a
-very small! Besides, SHE'S she, and I'm I, and--oh dear, how puzzling
-it all is! I'll try if I know all the things I used to know. Let me
+'I'm sure I'm not Ada,' she say, 'for her hair go in such long
+ringlet, and mine doesn't go in ringlet at all; and I'm sure I can't
+be Mabel, for I know all sort of things, and she, oh! she know such a
+very small! Besides, SHE'S she, and I'm I, and--oh dear, how puzzle
+it all is! I'll try if I know all the things I use to know. Let me
 see: 4 times 5 is 12, and 4 times 6 is 13, and
 4 times 7 is--oh dear! I shall never get to 20 at that rate!
 However, the Multiplication Table doesn't signify: let's try Geography.
 London is the cap of Paris, and Paris is the cap of Rome, and
-Rome--no, THAT'S all wrong, I'm sure! I must get been changed for
-Mabel! I'll try and say "How doth the small--"' and she crossed her
-hands on her lap as if she were saying lessons, and began to echo it,
-but her vox sounded hoarse and strange, and the words did not come the
-same as they used to do:--
+Rome--no, THAT'S all wrong, I'm sure! I must get be vary for
+Mabel! I'll try and say "How doth the small--"' and she span her
+hands on her lap as if she be saying lesson, and began to echo it,
+but her vox go hoarse and strange, and the words do not come the
+same as they use to do:--
 
      'How doth the small crocodile
       Improve his shining tail,
      And pour the waters of the Nile
       On every lucky scale!
 
-     'How cheerfully he seems to grin,
-      How neatly paste his claws,
-     And welcome small fishes in
-      With gently smiling jaws!'
+     'How cheerfully he seem to grin,
+      How neatly paste his claw,
+     And welcome small fish in
+      With gently smiling jaw!'
 
-'I'm sure those ar not the flop words,' said poor Alice, and her eyes
-filled with tears again as she went on, 'I must be Mabel after all, and
+'I'm sure those ar not the flop words,' say poor Alice, and her eyes
+fill with tears again as she go on, 'I must be Mabel after all, and
 I shall get to go and live in that poky small house, and get next to
-no toys to toy with, and oh! ever so many lessons to see! No, I've
-made up my mind most it; if I'm Mabel, I'll stay down here! It'll be no
-use their putting their heads down and saying "Come up again, dear!" I
+no toy to toy with, and oh! ever so many lesson to see! No, I've
+do up my mind most it; if I'm Mabel, I'll stay down here! It'll be no
+use their putting their head down and saying "Come up again, dear!" I
 shall only look up and say "Who am I so? Tell me that 1st, and so,
 if I ilk being that soul, I'll come up: if not, I'll stay down here
-till I'm somebody else"--but, oh dear!' cried Alice, with a sudden fit
-of tears, 'I do bid they WOULD put their heads down! I am so VERY tired
+till I'm somebody else"--but, oh dear!' cry Alice, with a sudden fit
+of tears, 'I do bid they WOULD put their head down! I am so VERY fag
 of being all lone here!'
 
-As she said this she looked down at her hands, and was surprised to see
-that she had put on 1 of the Rabbit's small white kid gloves while
-she was talking. 'How CAN I get done that?' she thought. 'I must
-be growing small again.' She got up and went to the table to bar
+As she say this she look down at her hands, and was surprise to see
+that she had put on 1 of the Rabbit's small white kid glove while
+she was talking. 'How CAN I get do that?' she thought. 'I must
+be growing small again.' She got up and go to the table to bar
 herself by it, and found that, as nearly as she could shot, she was now
-most 2 feet high, and was going on shrinking rapidly: she soon found
-out that the do of this was the fan she was holding, and she dropped
+most 2 ft high, and was going on shrinking rapidly: she soon found
+out that the do of this was the fan she was holding, and she drop
 it hastily, just in time to avoid shrinking off in all.
 
-'That WAS a narrow leak!' said Alice, a good deal scared at the
+'That WAS a narrow leak!' say Alice, a good deal scare at the
 sudden vary, but very glad to find herself ease in existence; 'and
-now for the garden!' and she ran with all speed back to the small door:
-but, alas! the small door was shut again, and the small lucky key was
+now for the garden!' and she go with all speed back to the small door:
+but, ala! the small door was shut again, and the small lucky key was
 lying on the glass table as before, 'and things ar worse than ever,'
 thought the poor kid, 'for I never was so small as this before, never!
 And I hold it's too bad, that it is!'
 
-As she said these words her ft slipped, and in another mo, plash!
+As she say these words her ft slip, and in another mo, plash!
 she was up to her chin in salt H2O. Her 1st idea was that she
-had somehow fallen into the sea, 'and in that case I can go back by
-railway,' she said to herself. (Alice had been to the seaside once in
+had somehow fall into the sea, 'and in that case I can go back by
+railway,' she say to herself. (Alice had be to the seaside once in
 her life, and had come to the general end, that wherever you go
-to on the side coast you find a list of bathing machines in the
-sea, some children digging in the sand with wooden spades, so a row
-of lodging houses, and slow them a railway post.) However, she soon
-made out that she was in the pool of tears which she had wept when she
-was 9 feet high.
+to on the side coast you find a list of bathing machine in the
+sea, some kid digging in the sand with wooden spade, so a row
+of lodging house, and slow them a railway post.) However, she soon
+do out that she was in the pool of tears which she had wept when she
+was 9 ft high.
 
-'I bid I hadn't cried so much!' said Alice, as she swam most, trying
-to find her way out. 'I shall be punished for it now, I say, by
-being drowned in my own tears! That WILL be a queer thing, to be sure!
+'I bid I hadn't cry so much!' say Alice, as she swam most, try
+to find her way out. 'I shall be punish for it now, I say, by
+being drown in my own tears! That WILL be a queer thing, to be sure!
 However, everything is queer to-day.'
 
-Just so she heard something splashing most in the pool a small way
-off, and she swam nearer to do out what it was: at 1st she thought
-it must be a walrus or hippo, but so she remembered how small
-she was now, and she soon made out that it was only a mouse that had
-slipped in ilk herself.
+Just so she try something splashing most in the pool a small way
+off, and she swam near to do out what it was: at 1st she thought
+it must be a walrus or hippo, but so she think how small
+she was now, and she soon do out that it was only a mouse that had
+slip in ilk herself.
 
 'Would it be of any use, now,' thought Alice, 'to talk to this mouse?
 Everything is so out-of-the-way down here, that I should think very
-likely it can talk: at any rate, there's no harm in trying.' So she
-began: 'O Mouse, do you know the way out of this pool? I am very tired
+likely it can talk: at any rate, there's no harm in try.' So she
+began: 'O Mouse, do you know the way out of this pool? I am very fag
 of swim most here, O Mouse!' (Alice thought this must be the flop
-way of speaking to a mouse: she had never done such a thing before, but
-she remembered having seen in her brother's Latin Grammar, 'A mouse--of
-a mouse--to a mouse--a mouse--O mouse!') The Mouse looked at her kinda
-inquisitively, and seemed to her to wink with 1 of its small eyes,
-but it said nil.
+way of speaking to a mouse: she had never do such a thing before, but
+she think get see in her brother's Latin Grammar, 'A mouse--of
+a mouse--to a mouse--a mouse--O mouse!') The Mouse look at her kinda
+inquisitively, and seem to her to wink with 1 of its small eyes,
+but it say nil.
 
 'Perhaps it doesn't see side,' thought Alice; 'I daresay it's
 a French mouse, come over with William the Conqueror.' (For, with all
 her knowledge of story, Alice had no very top whim how long ago
-anything had happened.) So she began again: 'Ou est ma chatte?' which
-was the 1st doom in her French lesson-book. The Mouse gave a
-sudden leap out of the H2O, and seemed to quake all over with fright.
-'Oh, I beg your pardon!' cried Alice hastily, afraid that she had hurt
-the poor animal's feelings. 'I quite forgot you didn't ilk cats.'
+anything had hap.) So she began again: 'Ou est ma chatte?' which
+was the 1st doom in her French lesson-book. The Mouse pay a
+sudden leap out of the H2O, and seem to quake all over with fright.
+'Oh, I beg your pardon!' cry Alice hastily, afraid that she had hurt
+the poor animal's feelings. 'I quite bury you didn't ilk cat.'
 
-'Not ilk cats!' cried the Mouse, in a sharp, passionate vox. 'Would
-YOU ilk cats if you were me?'
+'Not ilk cat!' cry the Mouse, in a sharp, passionate vox. 'Would
+YOU ilk cat if you be me?'
 
-'Well, perhaps not,' said Alice in a soothing tone: 'don't be wild
+'Well, perhaps not,' say Alice in a soothe tone: 'don't be wild
 most it. And yet I bid I could show you our cat Dinah: I think you'd
-take a fancy to cats if you could only see her. She is such a dear quiet
-thing,' Alice went on, half to herself, as she swam lazily most in the
-pool, 'and she sits purring so nicely by the fire, licking her paws and
+take a fancy to cat if you could only see her. She is such a dear quiet
+thing,' Alice go on, half to herself, as she swam lazily most in the
+pool, 'and she sit purr so nicely by the fire, licking her paw and
 washing her face--and she is such a nice soft thing to nurse--and she's
-such a cap 1 for catching mice--oh, I beg your pardon!' cried
-Alice again, for this time the Mouse was bristling all over, and she
+such a cap 1 for catching mice--oh, I beg your pardon!' cry
+Alice again, for this time the Mouse was uprise all over, and she
 mat sure it must be really pained. 'We won't talk most her any
 more if you'd kinda not.'
 
-'We so!' cried the Mouse, who was trembling down to the end of his
+'We so!' cry the Mouse, who was trembling down to the end of his
 tail. 'As if I would talk on such a case! Our home ever HATED
-cats: nasty, low, vulgar things! Don't let me try the name again!'
+cat: nasty, low, vulgar things! Don't let me try the name again!'
 
-'I won't so!' said Alice, in a great hurry to vary the case of
-conversation. 'Are you--are you fond--of--of dogs?' The Mouse did not
-reply, so Alice went on eagerly: 'There is such a nice small dog near
+'I won't so!' say Alice, in a great hurry to vary the case of
+conversation. 'Are you--are you fond--of--of dog?' The Mouse do not
+reply, so Alice go on eagerly: 'There is such a nice small dog near
 our house I should ilk to show you! A small bright-eyed terrier, you
 know, with oh, such long curly brown hair! And it'll fetch things when
-you flip them, and it'll sit up and beg for its dinner, and all sorts
-of things--I can't think half of them--and it belongs to a farmer,
-you know, and he says it's so utile, it's worth a C pounds! He
-says it kills all the rats and--oh dear!' cried Alice in a sorrowful
+you flip them, and it'll sit up and beg for its dinner, and all sort
+of things--I can't think half of them--and it go to a farmer,
+you know, and he say it's so utile, it's worth a C lb! He
+say it kill all the rat and--oh dear!' cry Alice in a sorrowful
 tone, 'I'm afraid I've pained it again!' For the Mouse was swim
 off from her as hard as it could go, and making quite a din in
-the pool as it went.
+the pool as it go.
 
-So she called softly after it, 'Mouse dear! Do come back again, and we
-won't talk most cats or dogs either, if you don't ilk them!' When the
-Mouse heard this, it turned round and swam slow back to her: its
-face was quite wan (with passion, Alice thought), and it said in a low
+So she call softly after it, 'Mouse dear! Do come back again, and we
+won't talk most cat or dog either, if you don't ilk them!' When the
+Mouse try this, it turn round and swam slow back to her: its
+face was quite wan (with passion, Alice thought), and it say in a low
 trembling vox, 'Let us get to the shore, and so I'll tell you my
-story, and you'll see why it is I hate cats and dogs.'
+story, and you'll see why it is I hate cat and dog.'
 
-It was high time to go, for the pool was getting quite crowded with the
-birds and animals that had fallen into it: there were a Duck and a Dodo,
-a Lory and an Eaglet, and several other odd creatures. Alice led the
+It was high time to go, for the pool was getting quite crowd with the
+bird and beast that had fall into it: there be a Duck and a Dodo,
+a Lory and an Eaglet, and several other odd tool. Alice led the
 way, and the unit party swam to the shore.
 
 
@@ -452,144 +452,144 @@ way, and the unit party swam to the shore.
 
 CHAPTER III. A Caucus-Race and a Long Tale
 
-They were so a queer-looking party that assembled on the bank--the
-birds with draggled feathers, the animals with their fur clinging shut
+They be so a queer-looking party that tack on the bank--the
+bird with draggled plume, the beast with their fur hang shut
 to them, and all dripping wet, span, and uncomfortable.
 
 The 1st head of row was, how to get dry again: they had a
-audience most this, and after a few minutes it seemed quite raw
+audience most this, and after a few minutes it seem quite raw
 to Alice to find herself talking familiarly with them, as if she had
-known them all her life. Indeed, she had quite a long debate with the
-Lory, who at last turned sulky, and would only say, 'I am older than
+know them all her life. Indeed, she had quite a long debate with the
+Lory, who at last turn sulky, and would only say, 'I am older than
 you, and must know best'; and this Alice would not allow without
-wise how old it was, and, as the Lory positively refused to tell its
-age, there was no more to be said.
+wise how old it was, and, as the Lory positively refuse to tell its
+age, there was no more to be say.
 
-At last the Mouse, who seemed to be a soul of say-so among them,
-called out, 'Sit down, all of you, and hear to me! I'LL soon do you
+At last the Mouse, who seem to be a soul of say-so among them,
+call out, 'Sit down, all of you, and hear to me! I'LL soon do you
 dry enough!' They all sat down at once, in a big ring, with the Mouse
-in the middle. Alice kept her eyes uneasily set on it, for she mat
-sure she would get a bad cold if she did not get dry very soon.
+in the middle. Alice kept her eyes uneasily fix on it, for she mat
+sure she would get a bad cold if she do not get dry very soon.
 
-'Ahem!' said the Mouse with an important air, 'ar you all ready? This
-is the driest thing I know. Silence all round, if you please! "William
-the Conqueror, whose do was favoured by the pope, was soon submitted
-to by the side, who wanted leaders, and had been of late much
-wonted to usurpation and conquest. Edwin and Morcar, the earls of
+'Ahem!' say the Mouse with an important air, 'ar you all ready? This
+is the dry thing I know. Silence all round, if you please! "William
+the Conqueror, whose do was favoured by the pope, was soon bow
+to by the side, who want leaders, and had be of late much
+wonted to usurpation and conquest. Edwin and Morcar, the earl of
 Mercia and Northumbria--"'
 
-'Ugh!' said the Lory, with a shiver.
+'Ugh!' say the Lory, with a shiver.
 
-'I beg your pardon!' said the Mouse, frowning, but very politely: 'Did
+'I beg your pardon!' say the Mouse, lour, but very politely: 'Did
 you talk?'
 
-'Not I!' said the Lory hastily.
+'Not I!' say the Lory hastily.
 
-'I thought you did,' said the Mouse. '--I go. "Edwin and Morcar,
-the earls of Mercia and Northumbria, stated for him: and yet Stigand,
+'I thought you do,' say the Mouse. '--I go. "Edwin and Morcar,
+the earl of Mercia and Northumbria, hold for him: and yet Stigand,
 the loyal archbishop of Canterbury, found it advisable--"'
 
-'Found WHAT?' said the Duck.
+'Found WHAT?' say the Duck.
 
 'Found IT,' the Mouse replied kinda crossly: 'of row you know what
 "it" way.'
 
-'I know what "it" way well enough, when I find a thing,' said the
-Duck: 'it's generally a frog or a worm. The head is, what did the
+'I know what "it" way well enough, when I find a thing,' say the
+Duck: 'it's generally a frog or a worm. The head is, what do the
 archbishop find?'
 
-The Mouse did not mark this head, but hastily went on, '"--found
+The Mouse do not mark this head, but hastily go on, '"--found
 it advisable to go with Edgar Atheling to see William and bid him the
 cap. William's deal at 1st was lead. But the insolence of his
-Normans--" How ar you getting on now, my dear?' it continued, turn
+Normans--" How ar you getting on now, my dear?' it keep, turn
 to Alice as it spoke.
 
-'As wet as ever,' said Alice in a melancholy tone: 'it doesn't seem to
+'As wet as ever,' say Alice in a melancholy tone: 'it doesn't seem to
 dry me at all.'
 
-'In that case,' said the Dodo solemnly, rising to its feet, 'I go
+'In that case,' say the Dodo solemnly, rising to its ft, 'I go
 that the meeting recess, for the quick adoption of more energetic
-remedies--'
+cure--'
 
-'Speak side!' said the Eaglet. 'I don't know the import of half
+'Speak side!' say the Eaglet. 'I don't know the import of half
 those long words, and, what's more, I don't trust you do either!' And
-the Eaglet set down its head to hide a grin: some of the other birds
+the Eaglet set down its head to hide a grin: some of the other bird
 tittered audibly.
 
-'What I was going to say,' said the Dodo in an pained tone, 'was, that
+'What I was going to say,' say the Dodo in an pained tone, 'was, that
 the best thing to get us dry would be a Caucus-race.'
 
-'What IS a Caucus-race?' said Alice; not that she wanted much to know,
-but the Dodo had paused as if it thought that SOMEBODY ought to talk,
-and no 1 else seemed inclined to say anything.
+'What IS a Caucus-race?' say Alice; not that she want much to know,
+but the Dodo had pause as if it thought that SOMEBODY ought to talk,
+and no 1 else seem incline to say anything.
 
-'Why,' said the Dodo, 'the best way to explain it is to do it.' (And, as
+'Why,' say the Dodo, 'the best way to explain it is to do it.' (And, as
 you might ilk to try the thing yourself, some winter day, I will tell
-you how the Dodo managed it.)
+you how the Dodo deal it.)
 
-First it marked out a race-course, in a sort of round, ('the exact
-form doesn't thing,' it said,) and so all the party were placed
+First it mark out a race-course, in a sort of round, ('the exact
+form doesn't thing,' it say,) and so all the party be put
 on the row, here and there. There was no 'One, 2, 3, and
-off,' but they began running when they liked, and left off when they
-liked, so that it was not easy to know when the run was over. However,
-when they had been running half an hr or so, and were quite dry again,
-the Dodo suddenly called out 'The run is over!' and they all crowded
+off,' but they began running when they like, and left off when they
+like, so that it was not easy to know when the run was over. However,
+when they had be running half an hr or so, and be quite dry again,
+the Dodo suddenly call out 'The run is over!' and they all crowd
 round it, panting, and asking, 'But who has won?'
 
 This head the Dodo could not reply without a great deal of thought,
-and it sat for a long time with 1 digit pressed upon its forehead
-(the view in which you usually see Shakspere, in the pictures
-of him), while the rest waited in quiet. At last the Dodo said,
-'EVERYBODY has won, and all must get prizes.'
+and it sat for a long time with 1 digit push upon its forehead
+(the view in which you usually see Shakspere, in the icon
+of him), while the rest wait in quiet. At last the Dodo say,
+'EVERYBODY has won, and all must get prize.'
 
-'But who is to pay the prizes?' quite a chorus of voices asked.
+'But who is to pay the prize?' quite a chorus of vox ask.
 
-'Why, SHE, of row,' said the Dodo, pointing to Alice with 1 digit;
-and the unit party at once crowded round her, calling out in a lost
+'Why, SHE, of row,' say the Dodo, point to Alice with 1 digit;
+and the unit party at once crowd round her, calling out in a fox
 way, 'Prizes! Prizes!'
 
 Alice had no idea what to do, and in despair she put her paw in her
-bag, and pulled out a box of comfits, (luckily the salt H2O had
-not got into it), and handed them round as prizes. There was exactly 1
+bag, and pull out a box of comfit, (luckily the salt H2O had
+not got into it), and hand them round as prize. There was exactly 1
 a-piece all round.
 
-'But she must get a prize herself, you know,' said the Mouse.
+'But she must get a prize herself, you know,' say the Mouse.
 
 'Of row,' the Dodo replied very gravely. 'What else get you got in
-your bag?' he went on, turn to Alice.
+your bag?' he go on, turn to Alice.
 
-'Only a thimble,' said Alice sadly.
+'Only a thimble,' say Alice sadly.
 
-'Hand it over here,' said the Dodo.
+'Hand it over here,' say the Dodo.
 
-Then they all crowded round her once more, while the Dodo solemnly
-presented the thimble, saying 'We beg your acceptance of this elegant
-thimble'; and, when it had ruined this short speech, they all cheered.
+Then they all crowd round her once more, while the Dodo solemnly
+pose the thimble, saying 'We beg your acceptance of this elegant
+thimble'; and, when it had finish this short speech, they all urge.
 
-Alice thought the unit thing very absurd, but they all looked so tomb
-that she did not dare to laugh; and, as she could not think of anything
-to say, she simply bowed, and took the thimble, looking as solemn as she
+Alice thought the unit thing very absurd, but they all look so tomb
+that she do not dare to laugh; and, as she could not think of anything
+to say, she simply bow, and took the thimble, looking as solemn as she
 could.
 
-The next thing was to eat the comfits: this caused some noise and
-mix-up, as the big birds complained that they could not taste
-theirs, and the small ones choked and had to be patted on the back.
+The next thing was to eat the comfit: this do some noise and
+mix-up, as the big bird kick that they could not taste
+theirs, and the small 1 gag and had to be patted on the back.
 However, it was over at last, and they sat down again in a ring, and
-begged the Mouse to tell them something more.
+beg the Mouse to tell them something more.
 
-'You promised to tell me your story, you know,' said Alice, 'and why
-it is you hate--C and D,' she added in a whisper, half afraid that it
+'You assure to tell me your story, you know,' say Alice, 'and why
+it is you hate--C and D,' she add in a whisper, half afraid that it
 would be pained again.
 
-'Mine is a long and a sad tale!' said the Mouse, turn to Alice, and
-sighing.
+'Mine is a long and a sad tale!' say the Mouse, turn to Alice, and
+sigh.
 
-'It IS a long tail, certainly,' said Alice, looking down with wonder at
-the Mouse's tail; 'but why do you call it sad?' And she kept on puzzling
+'It IS a long tail, certainly,' say Alice, looking down with wonder at
+the Mouse's tail; 'but why do you call it sad?' And she kept on puzzle
 most it while the Mouse was speaking, so that her idea of the tale was
 something ilk this:--
 
-         'Fury said to a
+         'Fury say to a
          mouse, That he
         met in the
        house,
@@ -635,60 +635,60 @@ something ilk this:--
            last."'
 
 
-'You ar not attending!' said the Mouse to Alice severely. 'What ar you
+'You ar not attending!' say the Mouse to Alice severely. 'What ar you
 thought of?'
 
-'I beg your pardon,' said Alice very humbly: 'you had got to the 5th
+'I beg your pardon,' say Alice very humbly: 'you had got to the 5th
 bend, I think?'
 
-'I had NOT!' cried the Mouse, sharp and very angrily.
+'I had NOT!' cry the Mouse, sharp and very angrily.
 
-'A knot!' said Alice, ever ready to do herself utile, and looking
+'A knot!' say Alice, ever ready to do herself utile, and looking
 uneasily most her. 'Oh, do let me aid to undo it!'
 
-'I shall do nil of the sort,' said the Mouse, getting up and walking
+'I shall do nil of the sort,' say the Mouse, getting up and walking
 off. 'You insult me by talking such bunk!'
 
-'I didn't mean it!' pleaded poor Alice. 'But you're so easy pained,
+'I didn't mean it!' plead poor Alice. 'But you're so easy pained,
 you know!'
 
 The Mouse only growled in reply.
 
-'Please come back and goal your story!' Alice called after it; and the
-others all joined in chorus, 'Yes, please do!' but the Mouse only shook
-its head impatiently, and walked a small faster.
+'Please come back and goal your story!' Alice call after it; and the
+others all join in chorus, 'Yes, please do!' but the Mouse only shook
+its head impatiently, and walk a small warm.
 
-'What a pity it wouldn't stay!' sighed the Lory, as soon as it was quite
+'What a pity it wouldn't stay!' sigh the Lory, as soon as it was quite
 out of ken; and an old Crab took the chance of saying to her
 girl 'Ah, my dear! Let this be a lesson to you never to lose
-YOUR mood!' 'Hold your knife, Ma!' said the young Crab, a small
+YOUR mood!' 'Hold your knife, Ma!' say the young Crab, a small
 snappishly. 'You're enough to try the patience of an oyster!'
 
-'I bid I had our Dinah here, I know I do!' said Alice aloud, addressing
+'I bid I had our Dinah here, I know I do!' say Alice aloud, call
 nobody in special. 'She'd soon fetch it back!'
 
-'And who is Dinah, if I might stake to ask the head?' said the
+'And who is Dinah, if I might stake to ask the head?' say the
 Lory.
 
 Alice replied eagerly, for she was ever ready to talk most her pet:
 'Dinah's our cat. And she's such a cap 1 for catching mice you
-can't think! And oh, I bid you could see her after the birds! Why,
+can't think! And oh, I bid you could see her after the bird! Why,
 she'll eat a small bird as soon as look at it!'
 
-This speech caused a singular esthesis among the party. Some of the
-birds hurried off at once: 1 old Magpie began wrap itself up very
+This speech do a singular esthesis among the party. Some of the
+bird hurried off at once: 1 old Magpie began wrap itself up very
 carefully, remarking, 'I really must be getting home; the night-air
-doesn't fit my throat!' and a Canary called out in a trembling vox to
-its children, 'Come off, my dears! It's high time you were all in bed!'
-On various pretexts they all moved off, and Alice was soon left lone.
+doesn't fit my throat!' and a Canary call out in a trembling vox to
+its kid, 'Come off, my dears! It's high time you be all in bed!'
+On various pretext they all go off, and Alice was soon left lone.
 
-'I bid I hadn't mentioned Dinah!' she said to herself in a melancholy
-tone. 'Nobody seems to ilk her, down here, and I'm sure she's the best
+'I bid I hadn't cite Dinah!' she say to herself in a melancholy
+tone. 'Nobody seem to ilk her, down here, and I'm sure she's the best
 cat in the man! Oh, my dear Dinah! I wonder if I shall ever see you
 any more!' And here poor Alice began to cry again, for she mat very
-lonely and low-spirited. In a small while, yet, she again heard
-a small pattering of footsteps in the space, and she looked up
-eagerly, half hoping that the Mouse had changed his mind, and was coming
+lonely and low-spirited. In a small while, yet, she again try
+a small patter of pace in the space, and she look up
+eagerly, half hope that the Mouse had vary his mind, and was coming
 back to goal his story.
 
 
@@ -696,448 +696,448 @@ back to goal his story.
 
 CHAPTER IV. The Rabbit Sends in a Little Bill
 
-It was the White Rabbit, trotting slow back again, and looking
-uneasily most as it went, as if it had lost something; and she heard
-it muttering to itself 'The Duchess! The Duchess! Oh my dear paws! Oh
-my fur and whiskers! She'll get me executed, as sure as ferrets ar
-ferrets! Where CAN I get dropped them, I wonder?' Alice guessed in a
-mo that it was looking for the fan and the pair of white kid gloves,
-and she very good-naturedly began hunting most for them, but they were
-nowhere to be seen--everything seemed to get changed since her swim in
+It was the White Rabbit, jog slow back again, and looking
+uneasily most as it go, as if it had lost something; and she try
+it muttering to itself 'The Duchess! The Duchess! Oh my dear paw! Oh
+my fur and whiskers! She'll get me execute, as sure as ferret ar
+ferret! Where CAN I get drop them, I wonder?' Alice guess in a
+mo that it was looking for the fan and the pair of white kid glove,
+and she very good-naturedly began hunting most for them, but they be
+nowhere to be seen--everything seem to get vary since her swim in
 the pool, and the great hall, with the glass table and the small door,
-had vanished completely.
+had fly completely.
 
-Very soon the Rabbit noticed Alice, as she went hunting most, and
-called out to her in an wild tone, 'Why, Mary Ann, what ARE you doing
-out here? Run home this mo, and fetch me a pair of gloves and a fan!
-Quick, now!' And Alice was so much scared that she ran off at once
-in the way it pointed to, without trying to explain the error it
-had made.
+Very soon the Rabbit mark Alice, as she go hunting most, and
+call out to her in an wild tone, 'Why, Mary Ann, what ARE you do
+out here? Run home this mo, and fetch me a pair of glove and a fan!
+Quick, now!' And Alice was so much scare that she go off at once
+in the way it point to, without try to explain the error it
+had do.
 
-'He took me for his housemaid,' she said to herself as she ran. 'How
-surprised he'll be when he finds out who I am! But I'd best take him
-his fan and gloves--that is, if I can find them.' As she said this, she
+'He took me for his housemaid,' she say to herself as she go. 'How
+surprise he'll be when he find out who I am! But I'd best take him
+his fan and gloves--that is, if I can find them.' As she say this, she
 came upon a neat small house, on the door of which was a vivid brass
-plate with the name 'W. RABBIT' etched upon it. She went in without
+plate with the name 'W. RABBIT' etch upon it. She go in without
 knocking, and hurried upstair, in great awe lest she should see the
-real Mary Ann, and be turned out of the house before she had found the
-fan and gloves.
+real Mary Ann, and be turn out of the house before she had found the
+fan and glove.
 
-'How queer it seems,' Alice said to herself, 'to be going messages for
-a cony! I say Dinah'll be sending me on messages next!' And she
-began fancying the sort of thing that would hap: '"Miss Alice! Come
+'How queer it seem,' Alice say to herself, 'to be going message for
+a cony! I say Dinah'll be sending me on message next!' And she
+began fancy the sort of thing that would hap: '"Miss Alice! Come
 here flat, and get ready for your walk!" "Coming in a min,
 nurse! But I've got to see that the mouse doesn't get out." Only I don't
-think,' Alice went on, 'that they'd let Dinah stop in the house if it
+think,' Alice go on, 'that they'd let Dinah stop in the house if it
 began order people most ilk that!'
 
 By this time she had found her way into a tidy small way with a table
-in the window, and on it (as she had hoped) a fan and 2 or 3 pairs
-of tiny white kid gloves: she took up the fan and a pair of the gloves,
+in the window, and on it (as she had hope) a fan and 2 or 3 pair
+of tiny white kid glove: she took up the fan and a pair of the glove,
 and was just going to lead the way, when her eye fell upon a small
 bottle that stood near the looking-glass. There was no label this time
-with the words 'DRINK ME,' but nevertheless she uncorked it and put it
-to her lips. 'I know SOMETHING interesting is sure to hap,' she said
+with the words 'DRINK ME,' but nevertheless she uncork it and put it
+to her lip. 'I know SOMETHING interest is sure to hap,' she say
 to herself, 'whenever I eat or tope anything; so I'll just see what
-this bottle does. I do hope it'll do me get big again, for really
-I'm quite tired of being such a tiny small thing!'
+this bottle doe. I do hope it'll do me get big again, for really
+I'm quite fag of being such a tiny small thing!'
 
-It did so so, and much sooner than she had expected: before she had
+It do so so, and much sooner than she had look: before she had
 drunk half the bottle, she found her head urgent against the cap,
 and had to stoop to save her neck from being low. She hastily put
 down the bottle, saying to herself 'That's quite enough--I hope I shan't
 get any more--As it is, I can't get out at the door--I do bid I hadn't
 drunk quite so much!'
 
-Alas! it was too late to bid that! She went on growing, and growing,
+Alas! it was too late to bid that! She go on growing, and growing,
 and very soon had to kneel down on the base: in another min there
-was not yet way for this, and she tried the core of lying down with
-1 elbow against the door, and the other arm curled round her head.
-Still she went on growing, and, as a last resource, she put 1 arm out
-of the window, and 1 ft up the chimney, and said to herself 'Now I
-can do no more, whatever happens. What WILL go of me?'
+was not yet way for this, and she try the core of lying down with
+1 elbow against the door, and the other arm curl round her head.
+Still she go on growing, and, as a last resource, she put 1 arm out
+of the window, and 1 ft up the chimney, and say to herself 'Now I
+can do no more, whatever hap. What WILL go of me?'
 
 Luckily for Alice, the small magic bottle had now had its full core,
-and she grew no larger: ease it was very uncomfortable, and, as there
-seemed to be no sort of chance of her ever getting out of the way
+and she get no larger: ease it was very uncomfortable, and, as there
+seem to be no sort of chance of her ever getting out of the way
 again, no wonder she mat unhappy.
 
-'It was much pleasanter at home,' thought poor Alice, 'when 1 wasn't
-ever growing larger and smaller, and being ordered most by mice and
-rabbits. I almost bid I hadn't gone down that rabbit-hole--and yet--and
+'It was much pleasant at home,' thought poor Alice, 'when 1 wasn't
+ever growing larger and smaller, and being say most by mice and
+cony. I almost bid I hadn't go down that rabbit-hole--and yet--and
 yet--it's kinda odd, you know, this sort of life! I do wonder what
-CAN get happened to me! When I used to say fairy-tales, I fancied that
-kind of thing never happened, and now here I am in the middle of 1!
-There ought to be a book written most me, that there ought! And when I
-get up, I'll pen one--but I'm grown up now,' she added in a sorrowful
+CAN get hap to me! When I use to say fairy-tales, I fancy that
+kind of thing never hap, and now here I am in the middle of 1!
+There ought to be a book pen most me, that there ought! And when I
+get up, I'll pen one--but I'm get up now,' she add in a sorrowful
 tone; 'at least there's no way to get up any more HERE.'
 
 'But so,' thought Alice, 'shall I NEVER get any older than I am
 now? That'll be a ease, 1 way--never to be an old woman--but
-then--always to get lessons to see! Oh, I shouldn't ilk THAT!'
+then--always to get lesson to see! Oh, I shouldn't ilk THAT!'
 
-'Oh, you foolish Alice!' she answered herself. 'How can you see
-lessons in here? Why, there's hardly way for YOU, and no way at all
+'Oh, you foolish Alice!' she reply herself. 'How can you see
+lesson in here? Why, there's hardly way for YOU, and no way at all
 for any lesson-books!'
 
-And so she went on, taking 1st 1 side and so the other, and making
-quite a conversation of it in all; but after a few minutes she heard
-a vox remote, and stopped to hear.
+And so she go on, taking 1st 1 side and so the other, and making
+quite a conversation of it in all; but after a few minutes she try
+a vox remote, and stop to hear.
 
-'Mary Ann! Mary Ann!' said the vox. 'Fetch me my gloves this mo!'
-Then came a small pattering of feet on the steps. Alice knew it was
-the Rabbit coming to look for her, and she trembled till she shook the
-house, quite forgetting that she was now most a M times as big
+'Mary Ann! Mary Ann!' say the vox. 'Fetch me my glove this mo!'
+Then came a small patter of ft on the steps. Alice knew it was
+the Rabbit coming to look for her, and she tremble till she shook the
+house, quite bury that she was now most a M times as big
 as the Rabbit, and had no reason to be afraid of it.
 
-Presently the Rabbit came up to the door, and tried to open it; but, as
-the door opened inwards, and Alice's elbow was pressed hard against it,
-that try proved a loser. Alice heard it say to itself 'Then I'll
+Presently the Rabbit came up to the door, and try to open it; but, as
+the door open inwards, and Alice's elbow was push hard against it,
+that try show a loser. Alice try it say to itself 'Then I'll
 go round and get in at the window.'
 
-'THAT you won't' thought Alice, and, after waiting till she fancied
-she heard the Rabbit just under the window, she suddenly paste out her
-paw, and made a bit in the air. She did not get hold of anything,
-but she heard a small pipe and a pin, and a ram of low glass,
-from which she concluded that it was just possible it had fallen into a
+'THAT you won't' thought Alice, and, after waiting till she fancy
+she try the Rabbit just under the window, she suddenly paste out her
+paw, and do a bit in the air. She do not get hold of anything,
+but she try a small pipe and a pin, and a ram of low glass,
+from which she close that it was just possible it had fall into a
 cucumber-frame, or something of the sort.
 
 Next came an wild voice--the Rabbit's--'Pat! Pat! Where ar you?' And
-so a vox she had never heard before, 'Sure so I'm here! Digging
-for apples, yer honour!'
+so a vox she had never try before, 'Sure so I'm here! Digging
+for apple, yer honour!'
 
-'Digging for apples, so!' said the Rabbit angrily. 'Here! Come and
+'Digging for apple, so!' say the Rabbit angrily. 'Here! Come and
 aid me out of THIS!' (Sounds of more low glass.)
 
 'Now tell me, Pat, what's that in the window?'
 
-'Sure, it's an arm, yer honour!' (He pronounced it 'arrum.')
+'Sure, it's an arm, yer honour!' (He say it 'arrum.')
 
-'An arm, you goose! Who ever saw 1 that size? Why, it fills the unit
+'An arm, you goose! Who ever saw 1 that size? Why, it fill the unit
 window!'
 
-'Sure, it does, yer honour: but it's an arm for all that.'
+'Sure, it doe, yer honour: but it's an arm for all that.'
 
 'Well, it's got no byplay there, at any rate: go and take it off!'
 
-There was a long quiet after this, and Alice could only try whispers
+There was a long quiet after this, and Alice could only try whisper
 now and so; such as, 'Sure, I don't ilk it, yer honour, at all, at
 all!' 'Do as I tell you, you coward!' and at last she paste out her
-paw again, and made another bit in the air. This time there were
-TWO small shrieks, and more sounds of low glass. 'What a list of
+paw again, and do another bit in the air. This time there be
+TWO small pipe, and more go of low glass. 'What a list of
 cucumber-frames there must be!' thought Alice. 'I wonder what they'll do
 next! As for pulling me out of the window, I only bid they COULD! I'm
 sure I don't want to stay in here any longer!'
 
-She waited for some time without hearing anything more: at last came a
-rumbling of small cartwheels, and the go of a good many voices
-all talking together: she made out the words: 'Where's the other
+She wait for some time without hearing anything more: at last came a
+rumbling of small cartwheel, and the go of a good many vox
+all talking together: she do out the words: 'Where's the other
 run?--Why, I hadn't to get but 1; Bill's got the other--Bill!
 fetch it here, lad!--Here, put 'em up at this corner--No, tie 'em
 together first--they don't hit half high enough yet--Oh! they'll
 do well enough; don't be particular--Here, Bill! get hold of this
 rope--Will the roof bear?--Mind that open slate--Oh, it's coming
-down! Heads below!' (a loud ram)--'Now, who did that?--It was Bill, I
+down! Heads below!' (a loud ram)--'Now, who do that?--It was Bill, I
 fancy--Who's to go down the chimney?--Nay, I shan't! YOU do it!--That I
-won't, so!--Bill's to go down--Here, Bill! the master says you're to
+won't, so!--Bill's to go down--Here, Bill! the master say you're to
 go down the chimney!'
 
-'Oh! So Bill's got to come down the chimney, has he?' said Alice to
+'Oh! So Bill's got to come down the chimney, has he?' say Alice to
 herself. 'Shy, they seem to put everything upon Bill! I wouldn't be in
 Bill's put for a good deal: this hearth is narrow, to be sure; but
 I THINK I can kick a small!'
 
-She drew her ft as far down the chimney as she could, and waited
-till she heard a small beast (she couldn't shot of what sort it was)
-scratching and scrambling most in the chimney shut above her: so,
-saying to herself 'This is Bill,' she gave 1 tart kick, and waited to
+She drew her ft as far down the chimney as she could, and wait
+till she try a small beast (she couldn't shot of what sort it was)
+scratching and jumble most in the chimney shut above her: so,
+saying to herself 'This is Bill,' she pay 1 tart kick, and wait to
 see what would hap next.
 
-The 1st thing she heard was a general chorus of 'There goes Bill!'
+The 1st thing she try was a general chorus of 'There go Bill!'
 so the Rabbit's vox along--'Catch him, you by the duck!' so
 quiet, and so another mix-up of voices--'Hold up his head--Brandy
-now--Don't gag him--How was it, old dude? What happened to you? Tell
+now--Don't gag him--How was it, old dude? What hap to you? Tell
 us all most it!'
 
 Last came a small lame, squeaking vox, ('That's Bill,' thought
 Alice,) 'Well, I hardly know--No more, thank ye; I'm best now--but I'm
-a deal too rattled to tell you--all I know is, something comes at me
-ilk a Jack-in-the-box, and up I goes ilk a sky-rocket!'
+a deal too fluster to tell you--all I know is, something come at me
+ilk a Jack-in-the-box, and up I go ilk a sky-rocket!'
 
-'So you did, old dude!' said the others.
+'So you do, old dude!' say the others.
 
-'We must burn the house down!' said the Rabbit's vox; and Alice called
+'We must burn the house down!' say the Rabbit's vox; and Alice call
 out as loud as she could, 'If you do. I'll set Dinah at you!'
 
 There was a dead quiet instantly, and Alice thought to herself, 'I
 wonder what they WILL do next! If they had any sense, they'd take the
-roof off.' After a min or 2, they began moving most again, and
-Alice heard the Rabbit say, 'A barrowful will do, to begin with.'
+roof off.' After a min or 2, they began go most again, and
+Alice try the Rabbit say, 'A barrowful will do, to begin with.'
 
 'A barrowful of WHAT?' thought Alice; but she had not long to doubt,
-for the next mo a shower of small pebbles came rattling in at the
+for the next mo a shower of small pebble came rattling in at the
 window, and some of them hit her in the face. 'I'll put a stop to this,'
-she said to herself, and yelled out, 'You'd best not do that again!'
-which produced another dead quiet.
+she say to herself, and cry out, 'You'd best not do that again!'
+which make another dead quiet.
 
-Alice noticed with some surprise that the pebbles were all turn into
-small cakes as they lay on the base, and a vivid idea came into her
-head. 'If I eat 1 of these cakes,' she thought, 'it's sure to do
+Alice mark with some surprise that the pebble be all turn into
+small bar as they lay on the base, and a vivid idea came into her
+head. 'If I eat 1 of these bar,' she thought, 'it's sure to do
 SOME vary in my size; and as it can't maybe do me larger, it must
 do me smaller, I say.'
 
-So she swallowed 1 of the cakes, and was delighted to find that she
+So she unsay 1 of the bar, and was enjoy to find that she
 began shrinking flat. As soon as she was small enough to get through
-the door, she ran out of the house, and found quite a crew of small
-animals and birds waiting remote. The poor small Lizard, Bill, was
-in the middle, being held up by 2 guinea-pigs, who were gift it
-something out of a bottle. They all made a hie at Alice the mo she
-appeared; but she ran off as hard as she could, and soon found herself
+the door, she go out of the house, and found quite a crew of small
+beast and bird waiting remote. The poor small Lizard, Bill, was
+in the middle, being held up by 2 guinea-pigs, who be gift it
+something out of a bottle. They all do a hie at Alice the mo she
+seem; but she go off as hard as she could, and soon found herself
 safe in a deep wood.
 
-'The 1st thing I've got to do,' said Alice to herself, as she wandered
+'The 1st thing I've got to do,' say Alice to herself, as she wander
 most in the wood, 'is to get to my flop size again; and the s
 thing is to find my way into that lovely garden. I think that will be
 the best plan.'
 
-It sounded an splendid plan, no doubt, and very neatly and simply
-staged; the only difficulty was, that she had not the smallest idea
-how to set most it; and while she was peering most uneasily among
-the trees, a small tart bark just over her head made her look up in a
+It go an splendid plan, no doubt, and very neatly and simply
+set; the only difficulty was, that she had not the small idea
+how to set most it; and while she was peer most uneasily among
+the tree, a small tart bark just over her head do her look up in a
 great hurry.
 
 An enormous pup was looking down at her with big round eyes, and
-feebly stretching out 1 paw, trying to jot her. 'Poor small thing!'
-said Alice, in a coaxing tone, and she tried hard to sing to it; but
-she was awful scared all the time at the thought that it might be
+feebly stretching out 1 paw, try to jot her. 'Poor small thing!'
+say Alice, in a coaxing tone, and she try hard to sing to it; but
+she was awful scare all the time at the thought that it might be
 hungry, in which case it would be very likely to eat her up in spite of
 all her coaxing.
 
-Hardly wise what she did, she picked up a small bit of stick, and
-held it out to the pup; whereupon the pup jumped into the air off
-all its feet at once, with a yip of enjoy, and rushed at the stick,
-and made trust to vex it; so Alice dodged slow a great thistle,
-to keep herself from being go over; and the mo she appeared on the
-other side, the pup made another hie at the stick, and tumbled head
-over heels in its hurry to get hold of it; so Alice, thought it was
-very ilk having a biz of toy with a cart-horse, and expecting every
-mo to be trampled under its feet, ran round the thistle again; so
-the pup began a series of short charges at the stick, running a very
-small way forwards each time and a long way back, and barking huskily
+Hardly wise what she do, she pick up a small bit of stick, and
+held it out to the pup; whereupon the pup jump into the air off
+all its ft at once, with a yip of enjoy, and hie at the stick,
+and do trust to vex it; so Alice dodge slow a great thistle,
+to keep herself from being go over; and the mo she seem on the
+other side, the pup do another hie at the stick, and tumble head
+over heel in its hurry to get hold of it; so Alice, thought it was
+very ilk get a biz of toy with a cart-horse, and look every
+mo to be trample under its ft, go round the thistle again; so
+the pup began a series of short bill at the stick, running a very
+small way forrad each time and a long way back, and bark huskily
 all the while, till at last it sat down a good way off, panting, with
 its knife hanging out of its mouth, and its great eyes half shut.
 
-This seemed to Alice a good chance for making her leak; so she
-set off at once, and ran till she was quite tired and out of breath, and
-till the puppy's bark sounded quite conk in the space.
+This seem to Alice a good chance for making her leak; so she
+set off at once, and go till she was quite fag and out of breath, and
+till the puppy's bark go quite conk in the space.
 
-'And yet what a dear small pup it was!' said Alice, as she leant
-against a goldcup to rest herself, and fanned herself with 1 of the
-leaves: 'I should get liked precept it tricks very much, if--if I'd
-only been the flop size to do it! Oh dear! I'd nearly forgotten that
-I've got to get up again! Let me see--how IS it to be managed? I
+'And yet what a dear small pup it was!' say Alice, as she tip
+against a goldcup to rest herself, and fan herself with 1 of the
+leaf: 'I should get like precept it trick very much, if--if I'd
+only be the flop size to do it! Oh dear! I'd nearly bury that
+I've got to get up again! Let me see--how IS it to be deal? I
 say I ought to eat or tope something or other; but the great
 head is, what?'
 
-The great head certainly was, what? Alice looked all round her at
-the flowers and the blades of grass, but she did not see anything that
-looked ilk the flop thing to eat or tope under the circumstances.
+The great head certainly was, what? Alice look all round her at
+the peak and the vane of grass, but she do not see anything that
+look ilk the flop thing to eat or tope under the circumstances.
 There was a big mushroom growing near her, most the same height as
-herself; and when she had looked under it, and on both sides of it, and
-slow it, it occurred to her that she might as well look and see what
+herself; and when she had look under it, and on both side of it, and
+slow it, it come to her that she might as well look and see what
 was on the top of it.
 
-She stretched herself up on tip, and peeped over the edge of the
+She extend herself up on tip, and peep over the edge of the
 mushroom, and her eyes now met those of a big caterpillar,
-that was posing on the top with its arms folded, quiet smoking a long
-hookah, and taking not the smallest mark of her or of anything else.
+that was posing on the top with its arms fold, quiet smoking a long
+hookah, and taking not the small mark of her or of anything else.
 
 
 
 
 CHAPTER V. Advice from a cat
 
-The cat and Alice looked at each other for some time in quiet:
-at last the cat took the hookah out of its mouth, and addressed
+The cat and Alice look at each other for some time in quiet:
+at last the cat took the hookah out of its mouth, and call
 her in a languid, sleepy vox.
 
-'Who ar YOU?' said the cat.
+'Who ar YOU?' say the cat.
 
-This was not an supporting gap for a conversation. Alice replied,
+This was not an encourage gap for a conversation. Alice replied,
 kinda shyly, 'I--I hardly know, sir, just at present--at least I know
-who I WAS when I got up this morn, but I think I must get been
-changed several times since so.'
+who I WAS when I got up this morn, but I think I must get be
+vary several times since so.'
 
-'What do you mean by that?' said the cat sternly. 'Explain
+'What do you mean by that?' say the cat sternly. 'Explain
 yourself!'
 
-'I can't explain MYSELF, I'm afraid, sir' said Alice, 'because I'm not
+'I can't explain MYSELF, I'm afraid, sir' say Alice, 'because I'm not
 myself, you see.'
 
-'I don't see,' said the cat.
+'I don't see,' say the cat.
 
 'I'm afraid I can't put it more clear,' Alice replied very politely,
 'for I can't see it myself to begin with; and being so many
-different sizes in a day is very puzzling.'
+different size in a day is very fox.'
 
-'It isn't,' said the cat.
+'It isn't,' say the cat.
 
-'Well, perhaps you haven't found it so yet,' said Alice; 'but when you
+'Well, perhaps you haven't found it so yet,' say Alice; 'but when you
 get to turn into a chrysalis--you will some day, you know--and so
 after that into a butterfly, I should think you'll feel it a small
 queer, won't you?'
 
-'Not a bit,' said the cat.
+'Not a bit,' say the cat.
 
-'Well, perhaps your feelings may be different,' said Alice; 'all I know
+'Well, perhaps your feelings may be different,' say Alice; 'all I know
 is, it would feel very queer to ME.'
 
-'You!' said the cat scornfully. 'Who ar YOU?'
+'You!' say the cat scornfully. 'Who ar YOU?'
 
-Which brought them back again to the root of the conversation.
-Alice mat a small irritated at the Caterpillar's making such VERY
-short remarks, and she drew herself up and said, very gravely, 'I think,
+Which get them back again to the root of the conversation.
+Alice mat a small irritate at the Caterpillar's making such VERY
+short input, and she drew herself up and say, very gravely, 'I think,
 you ought to tell me who YOU ar, 1st.'
 
-'Why?' said the cat.
+'Why?' say the cat.
 
-Here was another puzzling head; and as Alice could not think of any
-good reason, and as the cat seemed to be in a VERY unpleasant
-say of mind, she turned off.
+Here was another puzzle head; and as Alice could not think of any
+good reason, and as the cat seem to be in a VERY unpleasant
+say of mind, she turn off.
 
-'Come back!' the cat called after her. 'I've something important
+'Come back!' the cat call after her. 'I've something important
 to say!'
 
-This sounded promising, certainly: Alice turned and came back again.
+This go assure, certainly: Alice turn and came back again.
 
-'Keep your mood,' said the cat.
+'Keep your mood,' say the cat.
 
-'Is that all?' said Alice, swallowing down her ire as well as she
+'Is that all?' say Alice, unsay down her ire as well as she
 could.
 
-'No,' said the cat.
+'No,' say the cat.
 
 Alice thought she might as well wait, as she had nil else to do, and
 perhaps after all it might tell her something worth hearing. For some
-minutes it puffed off without speaking, but at last it unfolded its
-arms, took the hookah out of its mouth again, and said, 'So you think
-you're changed, do you?'
+minutes it puff off without speaking, but at last it open its
+arms, took the hookah out of its mouth again, and say, 'So you think
+you're vary, do you?'
 
-'I'm afraid I am, sir,' said Alice; 'I can't think things as I
+'I'm afraid I am, sir,' say Alice; 'I can't think things as I
 used--and I don't keep the same size for X minutes together!'
 
-'Can't think WHAT things?' said the cat.
+'Can't think WHAT things?' say the cat.
 
-'Well, I've tried to say "HOW DOTH THE LITTLE BUSY BEE," but it all came
+'Well, I've try to say "HOW DOTH THE LITTLE BUSY BEE," but it all came
 different!' Alice replied in a very melancholy vox.
 
-'Repeat, "YOU ARE OLD, FATHER WILLIAM,"' said the cat.
+'Repeat, "YOU ARE OLD, FATHER WILLIAM,"' say the cat.
 
-Alice folded her hands, and began:--
+Alice fold her hands, and began:--
 
-   'You ar old, Padre William,' the young man said,
+   'You ar old, Padre William,' the young man say,
     'And your hair has go very white;
    And yet you incessantly stand on your head--
     Do you think, at your age, it is flop?'
 
    'In my youth,' Padre William replied to his son,
-    'I feared it might wound the wit;
+    'I fear it might wound the wit;
    But, now that I'm perfectly sure I get none,
     Why, I do it again and again.'
 
-   'You ar old,' said the youth, 'as I mentioned before,
-    And get grown most uncommonly fat;
-   Yet you turned a back-somersault in at the door--
+   'You ar old,' say the youth, 'as I cite before,
+    And get get most uncommonly fat;
+   Yet you turn a back-somersault in at the door--
     Pray, what is the reason of that?'
 
-   'In my youth,' said the sage, as he shook his grey locks,
-    'I kept all my limbs very supple
+   'In my youth,' say the sage, as he shook his grey lock,
+    'I kept all my limb very supple
    By the use of this ointment--one shilling the box--
     Allow me to sell you a duo?'
 
-   'You ar old,' said the youth, 'and your jaws ar too weak
-    For anything tougher than suet;
-   Yet you ruined the goose, with the bones and the neb--
-    Pray how did you deal to do it?'
+   'You ar old,' say the youth, 'and your jaw ar too weak
+    For anything tough than suet;
+   Yet you finish the goose, with the bones and the neb--
+    Pray how do you deal to do it?'
 
-   'In my youth,' said his father, 'I took to the law,
-    And argued each case with my wife;
-   And the muscular strength, which it gave to my jaw,
-    Has lasted the rest of my life.'
+   'In my youth,' say his father, 'I took to the law,
+    And argue each case with my wife;
+   And the muscular strength, which it pay to my jaw,
+    Has last the rest of my life.'
 
-   'You ar old,' said the youth, '1 would hardly say
+   'You ar old,' say the youth, '1 would hardly say
     That your eye was as calm as ever;
-   Yet you balanced an eel on the end of your nose--
-    What made you so awfully clever?'
+   Yet you balance an eel on the end of your nose--
+    What do you so awfully clever?'
 
-   'I get answered 3 questions, and that is enough,'
+   'I get reply 3 head, and that is enough,'
     Said his father; 'don't pay yourself airs!
    Do you think I can hear all day to such lug?
     Be off, or I'll kick you down steps!'
 
 
-'That is not said flop,' said the cat.
+'That is not say flop,' say the cat.
 
-'Not QUITE flop, I'm afraid,' said Alice, timidly; 'some of the words
-get got altered.'
+'Not QUITE flop, I'm afraid,' say Alice, timidly; 'some of the words
+get got spay.'
 
-'It is wrong from root to end,' said the cat decidedly, and
+'It is wrong from root to end,' say the cat decidedly, and
 there was quiet for some minutes.
 
 The cat was the 1st to talk.
 
-'What size do you want to be?' it asked.
+'What size do you want to be?' it ask.
 
 'Oh, I'm not special as to size,' Alice hastily replied; 'only 1
-doesn't ilk changing so often, you know.'
+doesn't ilk vary so often, you know.'
 
-'I DON'T know,' said the cat.
+'I DON'T know,' say the cat.
 
-Alice said nil: she had never been so much contradicted in her life
-before, and she mat that she was losing her mood.
+Alice say nil: she had never be so much belie in her life
+before, and she mat that she was lose her mood.
 
-'Are you content now?' said the cat.
+'Are you content now?' say the cat.
 
 'Well, I should ilk to be a LITTLE larger, sir, if you wouldn't mind,'
-said Alice: '3 inches is such a wretched height to be.'
+say Alice: '3 in is such a wretched height to be.'
 
-'It is a very good height so!' said the cat angrily, rearing
-itself upright as it spoke (it was exactly 3 inches high).
+'It is a very good height so!' say the cat angrily, rearing
+itself upright as it spoke (it was exactly 3 in high).
 
-'But I'm not used to it!' pleaded poor Alice in a piteous tone. And
-she thought of herself, 'I bid the creatures wouldn't be so easy
+'But I'm not use to it!' plead poor Alice in a piteous tone. And
+she thought of herself, 'I bid the tool wouldn't be so easy
 pained!'
 
-'You'll get used to it in time,' said the cat; and it put the
+'You'll get use to it in time,' say the cat; and it put the
 hookah into its mouth and began smoking again.
 
-This time Alice waited patiently until it chose to talk again. In
+This time Alice wait patiently until it opt to talk again. In
 a min or 2 the cat took the hookah out of its mouth
-and yawned once or twice, and shook itself. Then it got down off the
-mushroom, and crawled off in the grass, but remarking as it went,
-'One side will do you get taller, and the other side will do you
-get shorter.'
+and yawn once or twice, and shook itself. Then it got down off the
+mushroom, and crawl off in the grass, but remarking as it go,
+'One side will do you get tall, and the other side will do you
+get short.'
 
 'One side of WHAT? The other side of WHAT?' thought Alice to herself.
 
-'Of the mushroom,' said the cat, just as if she had asked it
+'Of the mushroom,' say the cat, just as if she had ask it
 aloud; and in another mo it was out of ken.
 
-Alice remained looking thoughtfully at the mushroom for a min, trying
-to do out which were the 2 sides of it; and as it was perfectly
+Alice remain looking thoughtfully at the mushroom for a min, try
+to do out which be the 2 side of it; and as it was perfectly
 round, she found this a very hard head. However, at last she
-stretched her arms round it as far as they would go, and bust off a bit
+extend her arms round it as far as they would go, and bust off a bit
 of the edge with each paw.
 
-'And now which is which?' she said to herself, and nibbled a small of
+'And now which is which?' she say to herself, and pick a small of
 the right-hand bit to try the core: the next mo she mat a wild
-blow underneath her chin: it had struck her ft!
+blow underneath her chin: it had hit her ft!
 
-She was a good deal scared by this very sudden vary, but she mat
+She was a good deal scare by this very sudden vary, but she mat
 that there was no time to be lost, as she was shrinking rapidly; so she
-set to act at once to eat some of the other bit. Her chin was pressed
+set to act at once to eat some of the other bit. Her chin was push
 so nearly against her ft, that there was hardly way to open her
-mouth; but she did it at last, and managed to sup a bit of the
+mouth; but she do it at last, and deal to sup a bit of the
 lefthand bit.
 
 
@@ -1147,423 +1147,423 @@ lefthand bit.
 
   *    *    *    *    *    *    *
 
-'Come, my head's free at last!' said Alice in a tone of enjoy, which
-changed into alarm in another mo, when she found that her shoulders
-were nowhere to be found: all she could see, when she looked down, was
-an immense length of neck, which seemed to rise ilk a stem out of a
-sea of green leaves that lay far below her.
+'Come, my head's free at last!' say Alice in a tone of enjoy, which
+vary into alarm in another mo, when she found that her berm
+be nowhere to be found: all she could see, when she look down, was
+an immense length of neck, which seem to rise ilk a stem out of a
+sea of green leaf that lay far below her.
 
-'What CAN all that green lug be?' said Alice. 'And where HAVE my
-shoulders got to? And oh, my poor hands, how is it I can't see you?'
-She was moving them most as she spoke, but no ensue seemed to follow,
-except a small quiver among the remote green leaves.
+'What CAN all that green lug be?' say Alice. 'And where HAVE my
+berm got to? And oh, my poor hands, how is it I can't see you?'
+She was go them most as she spoke, but no ensue seem to follow,
+except a small quiver among the remote green leaf.
 
-As there seemed to be no chance of getting her hands up to her head, she
-tried to get her head down to them, and was delighted to find that her
+As there seem to be no chance of getting her hands up to her head, she
+try to get her head down to them, and was enjoy to find that her
 neck would bend most easy in any way, ilk a serpent. She had
-just succeeded in curving it down into a graceful zig, and was going
-to dive in among the leaves, which she found to be nil but the tops
-of the trees under which she had been roving, when a tart hiss made
-her tie back in a hurry: a big pigeon had flown into her face, and
+just win in curving it down into a graceful zig, and was going
+to dive in among the leaf, which she found to be nil but the top
+of the tree under which she had be roving, when a tart hiss do
+her tie back in a hurry: a big pigeon had fly into her face, and
 was lacing her violently with its wings.
 
-'Serpent!' screamed the Pigeon.
+'Serpent!' scream the Pigeon.
 
-'I'm NOT a serpent!' said Alice indignantly. 'Let me lone!'
+'I'm NOT a serpent!' say Alice indignantly. 'Let me lone!'
 
-'Serpent, I say again!' repeated the Pigeon, but in a more subdued tone,
-and added with a kind of sob, 'I've tried every way, and nil seems
+'Serpent, I say again!' echo the Pigeon, but in a more subdued tone,
+and add with a kind of sob, 'I've try every way, and nil seem
 to fit them!'
 
-'I haven't the least idea what you're talking most,' said Alice.
+'I haven't the least idea what you're talking most,' say Alice.
 
-'I've tried the roots of trees, and I've tried banks, and I've tried
-hedges,' the Pigeon went on, without attending to her; 'but those
-serpents! There's no pleasing them!'
+'I've try the roots of tree, and I've try banks, and I've try
+duck,' the Pigeon go on, without attending to her; 'but those
+serpent! There's no pleasing them!'
 
-Alice was more and more puzzled, but she thought there was no use in
-saying anything more till the Pigeon had ruined.
+Alice was more and more puzzle, but she thought there was no use in
+saying anything more till the Pigeon had finish.
 
-'As if it wasn't ail enough hatching the eggs,' said the Pigeon;
-'but I must be on the look-out for serpents dark and day! Why, I
-haven't had a wink of nap these 3 weeks!'
+'As if it wasn't ail enough hatching the eggs,' say the Pigeon;
+'but I must be on the look-out for serpent dark and day! Why, I
+haven't had a wink of nap these 3 week!'
 
-'I'm very sorry you've been riled,' said Alice, who was root to
+'I'm very sorry you've be rag,' say Alice, who was root to
 see its import.
 
-'And just as I'd taken the highest tree in the wood,' continued the
+'And just as I'd take the high tree in the wood,' keep the
 Pigeon, raising its vox to a pipe, 'and just as I was thought I
-should be free of them at last, they must needs come wriggling down from
+should be free of them at last, they must need come wriggling down from
 the sky! Ugh, Serpent!'
 
-'But I'm NOT a serpent, I tell you!' said Alice. 'I'm a--I'm a--'
+'But I'm NOT a serpent, I tell you!' say Alice. 'I'm a--I'm a--'
 
-'Well! WHAT ar you?' said the Pigeon. 'I can see you're trying to
+'Well! WHAT ar you?' say the Pigeon. 'I can see you're try to
 forge something!'
 
-'I--I'm a small girl,' said Alice, kinda dubiously, as she remembered
-the list of changes she had gone through that day.
+'I--I'm a small girl,' say Alice, kinda dubiously, as she think
+the list of vary she had go through that day.
 
-'A likely story so!' said the Pigeon in a tone of the deepest
-scorn. 'I've seen a good many small girls in my time, but never ONE
+'A likely story so!' say the Pigeon in a tone of the deep
+scorn. 'I've see a good many small girl in my time, but never ONE
 with such a neck as that! No, no! You're a serpent; and there's no use
-denying it. I say you'll be telling me next that you never tasted an
+deny it. I say you'll be telling me next that you never taste an
 egg!'
 
-'I HAVE tasted eggs, certainly,' said Alice, who was a very true
-kid; 'but small girls eat eggs quite as much as serpents do, you
+'I HAVE taste eggs, certainly,' say Alice, who was a very true
+kid; 'but small girl eat eggs quite as much as serpent do, you
 know.'
 
-'I don't trust it,' said the Pigeon; 'but if they do, why so they're
+'I don't trust it,' say the Pigeon; 'but if they do, why so they're
 a kind of serpent, that's all I can say.'
 
 This was such a new idea to Alice, that she was quite still for a
-min or 2, which gave the Pigeon the chance of adding, 'You're
-looking for eggs, I know THAT well enough; and what does it thing to me
+min or 2, which pay the Pigeon the chance of add, 'You're
+looking for eggs, I know THAT well enough; and what doe it thing to me
 whether you're a small girl or a serpent?'
 
-'It matters a good deal to ME,' said Alice hastily; 'but I'm not looking
-for eggs, as it happens; and if I was, I shouldn't want YOURS: I don't
+'It thing a good deal to ME,' say Alice hastily; 'but I'm not looking
+for eggs, as it hap; and if I was, I shouldn't want YOURS: I don't
 ilk them raw.'
 
-'Well, be off, so!' said the Pigeon in a sulky tone, as it settled
-down again into its nest. Alice crouched down among the trees as well as
-she could, for her neck kept getting entangled among the branches, and
+'Well, be off, so!' say the Pigeon in a sulky tone, as it root
+down again into its nest. Alice bow down among the tree as well as
+she could, for her neck kept getting mat among the arm, and
 every now and so she had to stop and untwist it. After a while she
-remembered that she ease held the pieces of mushroom in her hands, and
-she set to act very carefully, nibbling 1st at 1 and so at the
-other, and growing sometimes taller and sometimes shorter, until she had
-succeeded in bringing herself down to her usual height.
+think that she ease held the bit of mushroom in her hands, and
+she set to act very carefully, pick 1st at 1 and so at the
+other, and growing sometimes tall and sometimes short, until she had
+win in bringing herself down to her usual height.
 
-It was so long since she had been anything near the flop size, that it
-mat quite strange at 1st; but she got used to it in a few minutes,
-and began talking to herself, as usual. 'Come, there's half my plan done
-now! How puzzling all these changes ar! I'm never sure what I'm going
+It was so long since she had be anything near the flop size, that it
+mat quite strange at 1st; but she got use to it in a few minutes,
+and began talking to herself, as usual. 'Come, there's half my plan do
+now! How puzzle all these vary ar! I'm never sure what I'm going
 to be, from 1 min to another! However, I've got back to my flop
 size: the next thing is, to get into that beautiful garden--how IS that
-to be done, I wonder?' As she said this, she came suddenly upon an open
-put, with a small house in it most 4 feet high. 'Whoever lives
+to be do, I wonder?' As she say this, she came suddenly upon an open
+put, with a small house in it most 4 ft high. 'Whoever life
 there,' thought Alice, 'it'll never do to come upon them THIS size: why,
-I should scare them out of their wits!' So she began nibbling at the
-righthand bit again, and did not stake to go near the house till she
-had brought herself down to 9 inches high.
+I should scare them out of their wits!' So she began pick at the
+righthand bit again, and do not stake to go near the house till she
+had get herself down to 9 in high.
 
 
 
 
 CHAPTER VI. Pig and Pepper
 
-For a min or 2 she stood looking at the house, and wondering what
+For a min or 2 she stood looking at the house, and wonder what
 to do next, when suddenly a footman in livery came running out of the
-wood--(she considered him to be a footman because he was in livery:
-otherwise, judging by his face only, she would get called him a
-fish)--and rapped loud at the door with his knuckles. It was opened
+wood--(she take him to be a footman because he was in livery:
+otherwise, judging by his face only, she would get call him a
+fish)--and rap loud at the door with his knuckles. It was open
 by another footman in livery, with a round face, and big eyes ilk a
-frog; and both footmen, Alice noticed, had powdery hair that curled all
-over their heads. She mat very odd to know what it was all most,
+frog; and both footmen, Alice mark, had powder hair that curl all
+over their head. She mat very odd to know what it was all most,
 and crept a small way out of the wood to hear.
 
-The Fish-Footman began by producing from under his arm a great letter,
-nearly as big as himself, and this he handed over to the other,
+The Fish-Footman began by make from under his arm a great letter,
+nearly as big as himself, and this he hand over to the other,
 saying, in a solemn tone, 'For the Duchess. An invitation from the Queen
-to toy croquet.' The Frog-Footman repeated, in the same solemn tone,
-only changing the say of the words a small, 'From the Queen. An
+to toy croquet.' The Frog-Footman echo, in the same solemn tone,
+only vary the say of the words a small, 'From the Queen. An
 invitation for the Duchess to toy croquet.'
 
-Then they both bowed low, and their curls got entangled together.
+Then they both bow low, and their curl got mat together.
 
-Alice laughed so much at this, that she had to go back into the
-wood for awe of their hearing her; and when she next peeped out the
-Fish-Footman was gone, and the other was posing on the earth near the
-door, staring stupidly up into the sky.
+Alice laugh so much at this, that she had to go back into the
+wood for awe of their hearing her; and when she next peep out the
+Fish-Footman was go, and the other was posing on the earth near the
+door, stare stupidly up into the sky.
 
-Alice went timidly up to the door, and knocked.
+Alice go timidly up to the door, and knock.
 
-'There's no sort of use in knocking,' said the Footman, 'and that for
-2 reasons. First, because I'm on the same side of the door as you
+'There's no sort of use in knocking,' say the Footman, 'and that for
+2 reason. First, because I'm on the same side of the door as you
 ar; secondly, because they're making such a noise inner, no 1 could
 maybe try you.' And certainly there was a most sinful noise
 going on within--a constant howling and sneezing, and every now and so
-a great ram, as if a dish or kettle had been low to pieces.
+a great ram, as if a dish or kettle had be low to bit.
 
-'Please, so,' said Alice, 'how am I to get in?'
+'Please, so,' say Alice, 'how am I to get in?'
 
-'There might be some sense in your knocking,' the Footman went on
+'There might be some sense in your knocking,' the Footman go on
 without attending to her, 'if we had the door 'tween us. For instance,
-if you were INSIDE, you might rap, and I could let you out, you know.'
+if you be INSIDE, you might rap, and I could let you out, you know.'
 He was looking up into the sky all the time he was speaking, and this
 Alice thought decidedly rude. 'But perhaps he can't aid it,' she
-said to herself; 'his eyes ar so VERY nearly at the top of his head.
+say to herself; 'his eyes ar so VERY nearly at the top of his head.
 But at any rate he might reply questions.--How am I to get in?' she
-repeated, aloud.
+echo, aloud.
 
 'I shall sit here,' the Footman remarked, 'till tomorrow--'
 
-At this mo the door of the house opened, and a big plate came
-skimming out, unbent at the Footman's head: it just grazed his nose,
-and bust to pieces against 1 of the trees slow him.
+At this mo the door of the house open, and a big plate came
+skimming out, unbent at the Footman's head: it just rake his nose,
+and bust to bit against 1 of the tree slow him.
 
-'--or next day, maybe,' the Footman continued in the same tone, exactly
-as if nil had happened.
+'--or next day, maybe,' the Footman keep in the same tone, exactly
+as if nil had hap.
 
-'How am I to get in?' asked Alice again, in a louder tone.
+'How am I to get in?' ask Alice again, in a loud tone.
 
-'ARE you to get in at all?' said the Footman. 'That's the 1st
+'ARE you to get in at all?' say the Footman. 'That's the 1st
 head, you know.'
 
-It was, no doubt: only Alice did not ilk to be told so. 'It's really
-dreadful,' she muttered to herself, 'the way all the creatures argue.
+It was, no doubt: only Alice do not ilk to be told so. 'It's really
+dreadful,' she muttered to herself, 'the way all the tool argue.
 It's enough to get 1 wild!'
 
-The Footman seemed to think this a good chance for repeating his
-input, with variations. 'I shall sit here,' he said, 'on and off, for
+The Footman seem to think this a good chance for repeating his
+input, with variance. 'I shall sit here,' he say, 'on and off, for
 days and days.'
 
-'But what am I to do?' said Alice.
+'But what am I to do?' say Alice.
 
-'Anything you ilk,' said the Footman, and began whistling.
+'Anything you ilk,' say the Footman, and began whistling.
 
-'Oh, there's no use in talking to him,' said Alice desperately: 'he's
-perfectly idiotic!' And she opened the door and went in.
+'Oh, there's no use in talking to him,' say Alice desperately: 'he's
+perfectly idiotic!' And she open the door and go in.
 
 The door led flop into a big kitchen, which was full of fume from
 1 end to the other: the Duchess was posing on a three-legged shit in
 the middle, nursing a baby; the fix was leaning over the fire, stirring
-a big cauldron which seemed to be full of soup.
+a big cauldron which seem to be full of soup.
 
-'There's certainly too much pelt in that soup!' Alice said to herself,
+'There's certainly too much pelt in that soup!' Alice say to herself,
 as well as she could for sneezing.
 
 There was certainly too much of it in the air. Even the Duchess
-sneezed at times; and as for the baby, it was sneezing and howling
+sneeze at times; and as for the baby, it was sneezing and howling
 alternately without a moment's pause. The only things in the kitchen
-that did not sneeze, were the fix, and a big cat which was posing on
+that do not sneeze, be the fix, and a big cat which was posing on
 the hearth and grinning from ear to ear.
 
-'Please would you tell me,' said Alice, a small timidly, for she was
+'Please would you tell me,' say Alice, a small timidly, for she was
 not quite sure whether it was good manners for her to talk 1st, 'why
-your cat grins ilk that?'
+your cat grin ilk that?'
 
-'It's a Cheshire cat,' said the Duchess, 'and that's why. Pig!'
+'It's a Cheshire cat,' say the Duchess, 'and that's why. Pig!'
 
-She said the last word with such sudden force that Alice quite
-jumped; but she saw in another mo that it was addressed to the baby,
-and not to her, so she took courage, and went on again:--
+She say the last word with such sudden force that Alice quite
+jump; but she saw in another mo that it was call to the baby,
+and not to her, so she took courage, and go on again:--
 
-'I didn't know that Cheshire cats ever grinned; in fact, I didn't know
-that cats COULD grin.'
+'I didn't know that Cheshire cat ever grin; in fact, I didn't know
+that cat COULD grin.'
 
-'They all can,' said the Duchess; 'and most of 'em do.'
+'They all can,' say the Duchess; 'and most of 'em do.'
 
-'I don't know of any that do,' Alice said very politely, feeling quite
-pleased to get got into a conversation.
+'I don't know of any that do,' Alice say very politely, feeling quite
+please to get got into a conversation.
 
-'You don't know much,' said the Duchess; 'and that's a fact.'
+'You don't know much,' say the Duchess; 'and that's a fact.'
 
-Alice did not at all ilk the tone of this input, and thought it would
+Alice do not at all ilk the tone of this input, and thought it would
 be as well to present some other case of conversation. While she
-was trying to fix on 1, the fix took the cauldron of soup off the
-fire, and at once set to act throwing everything within her hit at
-the Duchess and the baby--the fire-irons came 1st; so followed a
-shower of saucepans, plates, and dishes. The Duchess took no mark of
+was try to fix on 1, the fix took the cauldron of soup off the
+fire, and at once set to act flip everything within her hit at
+the Duchess and the baby--the fire-irons came 1st; so follow a
+shower of saucepan, plate, and dish. The Duchess took no mark of
 them yet when they hit her; and the baby was howling so much already,
-that it was quite impossible to say whether the blows hurt it or not.
+that it was quite impossible to say whether the blow hurt it or not.
 
-'Oh, PLEASE mind what you're doing!' cried Alice, jumping up and down in
-an agony of brat. 'Oh, there goes his PRECIOUS nose'; as an unco
-big saucepan flew shut by it, and very nearly carried it off.
+'Oh, PLEASE mind what you're do!' cry Alice, jumping up and down in
+an agony of brat. 'Oh, there go his PRECIOUS nose'; as an unco
+big saucepan fly shut by it, and very nearly run it off.
 
-'If everybody minded their own byplay,' the Duchess said in a hoarse
-growl, 'the man would go round a deal faster than it does.'
+'If everybody mind their own byplay,' the Duchess say in a hoarse
+growl, 'the man would go round a deal fast than it doe.'
 
-'Which would NOT be an reward,' said Alice, who mat very glad to get
+'Which would NOT be an reward,' say Alice, who mat very glad to get
 an chance of showing off a small of her knowledge. 'Just think of
-what act it would do with the day and dark! You see the earth takes
+what act it would do with the day and dark! You see the earth take
 24 hours to turn round on its axis--'
 
-'Talking of axes,' said the Duchess, 'chop off her head!'
+'Talking of ax,' say the Duchess, 'chop off her head!'
 
-Alice glanced kinda uneasily at the fix, to see if she meant to take
-the hint; but the fix was busily stirring the soup, and seemed not to
-be hearing, so she went on again: 'Twenty-four hours, I THINK; or is
+Alice peek kinda uneasily at the fix, to see if she mean to take
+the hint; but the fix was busily stirring the soup, and seem not to
+be hearing, so she go on again: 'Twenty-four hours, I THINK; or is
 it 12? I--'
 
-'Oh, don't bother ME,' said the Duchess; 'I never could abide figures!'
+'Oh, don't bother ME,' say the Duchess; 'I never could abide fig!'
 And with that she began nursing her kid again, singing a sort of
-lullaby to it as she did so, and gift it a wild shake at the end of
+lullaby to it as she do so, and gift it a wild shake at the end of
 every line:
 
    'Speak rough to your small boy,
-    And beat him when he sneezes:
-   He only does it to rag,
-    Because he knows it teases.'
+    And beat him when he sneeze:
+   He only doe it to rag,
+    Because he know it bug.'
 
          CHORUS.
 
- (In which the fix and the baby joined):--
+ (In which the fix and the baby join):--
 
        'Wow! wow! wow!'
 
-While the Duchess sang the s verse of the song, she kept tossing
-the baby violently up and down, and the poor small thing howled so,
+While the Duchess sang the s verse of the song, she kept toss
+the baby violently up and down, and the poor small thing howl so,
 that Alice could hardly try the words:--
 
    'I talk severely to my boy,
-    I beat him when he sneezes;
+    I beat him when he sneeze;
    For he can good bask
-    The pelt when he pleases!'
+    The pelt when he plea!'
 
          CHORUS.
 
        'Wow! wow! wow!'
 
-'Here! you may nurse it a bit, if you ilk!' the Duchess said to Alice,
-flinging the baby at her as she spoke. 'I must go and get ready to toy
-croquet with the Queen,' and she hurried out of the way. The fix threw
-a frying-pan after her as she went out, but it just missed her.
+'Here! you may nurse it a bit, if you ilk!' the Duchess say to Alice,
+fling the baby at her as she spoke. 'I must go and get ready to toy
+croquet with the Queen,' and she hurried out of the way. The fix flip
+a frying-pan after her as she go out, but it just miss her.
 
-Alice caught the baby with some difficulty, as it was a queer-shaped
-small tool, and held out its arms and legs in all directions, 'just
+Alice get the baby with some difficulty, as it was a queer-shaped
+small tool, and held out its arms and legs in all way, 'just
 ilk a star-fish,' thought Alice. The poor small thing was snorting
-ilk a steam-engine when she caught it, and kept double itself up and
-straightening itself out again, so that in all, for the 1st min
+ilk a steam-engine when she get it, and kept double itself up and
+unbend itself out again, so that in all, for the 1st min
 or 2, it was as much as she could do to hold it.
 
-As soon as she had made out the right way of nursing it, (which was to
+As soon as she had do out the right way of nursing it, (which was to
 turn it up into a sort of knot, and so keep tight hold of its flop
-ear and left ft, so as to keep its undoing itself,) she carried
+ear and left ft, so as to keep its undoing itself,) she run
 it out into the open air. 'IF I don't take this kid off with me,'
 thought Alice, 'they're sure to kill it in a day or 2: wouldn't it be
-hit to lead it slow?' She said the last words out loud, and the
-small thing grunted in reply (it had left off sneezing by this time).
-'Don't oink,' said Alice; 'that's not at all a right way of expressing
+hit to lead it slow?' She say the last words out loud, and the
+small thing grunt in reply (it had left off sneezing by this time).
+'Don't oink,' say Alice; 'that's not at all a right way of show
 yourself.'
 
-The baby grunted again, and Alice looked very uneasily into its face to
+The baby grunt again, and Alice look very uneasily into its face to
 see what was the thing with it. There could be no doubt that it had
 a VERY turn-up nose, much more ilk a neb than a real nose; also its
-eyes were getting super small for a baby: in all Alice did not
+eyes be getting super small for a baby: in all Alice do not
 ilk the look of the thing at all. 'But perhaps it was only sobbing,'
-she thought, and looked into its eyes again, to see if there were any
+she thought, and look into its eyes again, to see if there be any
 tears.
 
-No, there were no tears. 'If you're going to turn into a pig, my dear,'
-said Alice, seriously, 'I'll get nil more to do with you. Mind
-now!' The poor small thing sobbed again (or grunted, it was impossible
-to say which), and they went on for some while in quiet.
+No, there be no tears. 'If you're going to turn into a pig, my dear,'
+say Alice, seriously, 'I'll get nil more to do with you. Mind
+now!' The poor small thing sob again (or grunt, it was impossible
+to say which), and they go on for some while in quiet.
 
 Alice was just root to think to herself, 'Now, what am I to do with
-this tool when I get it home?' when it grunted again, so violently,
-that she looked down into its face in some alarm. This time there could
+this tool when I get it home?' when it grunt again, so violently,
+that she look down into its face in some alarm. This time there could
 be NO error most it: it was neither more nor less than a pig, and she
 mat that it would be quite absurd for her to run it further.
 
-So she set the small tool down, and mat quite relieved to see
-it jog off quiet into the wood. 'If it had grown up,' she said
-to herself, 'it would get made a awfully ugly kid: but it makes
+So she set the small tool down, and mat quite relieve to see
+it jog off quiet into the wood. 'If it had get up,' she say
+to herself, 'it would get do a awfully ugly kid: but it do
 kinda a handsome pig, I think.' And she began thought over other
-children she knew, who might do very well as pigs, and was just saying
+kid she knew, who might do very well as pig, and was just saying
 to herself, 'if 1 only knew the flop way to vary them--' when she
-was a small startled by seeing the Cheshire Cat posing on a bough of a
-tree a few yards off.
+was a small jump by seeing the Cheshire Cat posing on a bough of a
+tree a few yard off.
 
-The Cat only grinned when it saw Alice. It looked good-natured, she
-thought: ease it had VERY long claws and a great many teeth, so she
-mat that it ought to be treated with value.
+The Cat only grin when it saw Alice. It look good-natured, she
+thought: ease it had VERY long claw and a great many teeth, so she
+mat that it ought to be treat with value.
 
-'Cheshire Puss,' she began, kinda timidly, as she did not at all know
-whether it would ilk the name: yet, it only grinned a small wider.
-'Come, it's pleased so far,' thought Alice, and she went on. 'Would you
+'Cheshire Puss,' she began, kinda timidly, as she do not at all know
+whether it would ilk the name: yet, it only grin a small wide.
+'Come, it's please so far,' thought Alice, and she go on. 'Would you
 tell me, please, which way I ought to go from here?'
 
-'That depends a good deal on where you want to get to,' said the Cat.
+'That depend a good deal on where you want to get to,' say the Cat.
 
-'I don't much aid where--' said Alice.
+'I don't much aid where--' say Alice.
 
-'Then it doesn't thing which way you go,' said the Cat.
+'Then it doesn't thing which way you go,' say the Cat.
 
-'--so long as I get SOMEWHERE,' Alice added as an account.
+'--so long as I get SOMEWHERE,' Alice add as an account.
 
-'Oh, you're sure to do that,' said the Cat, 'if you only walk long
+'Oh, you're sure to do that,' say the Cat, 'if you only walk long
 enough.'
 
-Alice mat that this could not be denied, so she tried another head.
+Alice mat that this could not be deny, so she try another head.
 'What sort of people live most here?'
 
-'In THAT way,' the Cat said, waving its flop paw round, 'lives
-a Hatter: and in THAT way,' waving the other paw, 'lives a Mar
+'In THAT way,' the Cat say, waving its flop paw round, 'life
+a Hatter: and in THAT way,' waving the other paw, 'life a Mar
 Hare. Visit either you ilk: they're both mad.'
 
 'But I don't want to go among mad people,' Alice remarked.
 
-'Oh, you can't aid that,' said the Cat: 'we're all mad here. I'm mad.
+'Oh, you can't aid that,' say the Cat: 'we're all mad here. I'm mad.
 You're mad.'
 
-'How do you know I'm mad?' said Alice.
+'How do you know I'm mad?' say Alice.
 
-'You must be,' said the Cat, 'or you wouldn't get come here.'
+'You must be,' say the Cat, 'or you wouldn't get come here.'
 
-Alice didn't think that proved it at all; yet, she went on 'And how
+Alice didn't think that show it at all; yet, she go on 'And how
 do you know that you're mad?'
 
-'To begin with,' said the Cat, 'a dog's not mad. You give that?'
+'To begin with,' say the Cat, 'a dog's not mad. You give that?'
 
-'I say so,' said Alice.
+'I say so,' say Alice.
 
-'Well, so,' the Cat went on, 'you see, a dog growls when it's wild,
-and wags its tail when it's pleased. Now I growl when I'm pleased, and
+'Well, so,' the Cat go on, 'you see, a dog growl when it's wild,
+and wag its tail when it's please. Now I growl when I'm please, and
 wag my tail when I'm wild. Therefore I'm mad.'
 
-'I call it purring, not growling,' said Alice.
+'I call it purr, not growling,' say Alice.
 
-'Call it what you ilk,' said the Cat. 'Do you toy croquet with the
+'Call it what you ilk,' say the Cat. 'Do you toy croquet with the
 Queen to-day?'
 
-'I should ilk it very much,' said Alice, 'but I haven't been invited
+'I should ilk it very much,' say Alice, 'but I haven't be bid
 yet.'
 
-'You'll see me there,' said the Cat, and vanished.
+'You'll see me there,' say the Cat, and fly.
 
-Alice was not much surprised at this, she was getting so used to queer
-things happening. While she was looking at the put where it had been,
-it suddenly appeared again.
+Alice was not much surprise at this, she was getting so use to queer
+things happening. While she was looking at the put where it had be,
+it suddenly seem again.
 
-'By-the-bye, what became of the baby?' said the Cat. 'I'd nearly
-forgotten to ask.'
+'By-the-bye, what go of the baby?' say the Cat. 'I'd nearly
+bury to ask.'
 
-'It turned into a pig,' Alice quiet said, just as if it had come back
+'It turn into a pig,' Alice quiet say, just as if it had come back
 in a raw way.
 
-'I thought it would,' said the Cat, and vanished again.
+'I thought it would,' say the Cat, and fly again.
 
-Alice waited a small, half expecting to see it again, but it did not
-seem, and after a min or 2 she walked on in the way in
-which the Mar Hare was said to live. 'I've seen hatters before,' she
-said to herself; 'the Mar Hare will be much the most interesting, and
+Alice wait a small, half look to see it again, but it do not
+seem, and after a min or 2 she walk on in the way in
+which the Mar Hare was say to live. 'I've see hatters before,' she
+say to herself; 'the Mar Hare will be much the most interest, and
 perhaps as this is May it won't be raving mad--at least not so mad as
-it was in Mar.' As she said this, she looked up, and there was the Cat
+it was in Mar.' As she say this, she look up, and there was the Cat
 again, posing on a arm of a tree.
 
-'Did you say pig, or fig?' said the Cat.
+'Did you say pig, or fig?' say the Cat.
 
-'I said pig,' replied Alice; 'and I bid you wouldn't keep appearing and
+'I say pig,' replied Alice; 'and I bid you wouldn't keep appearing and
 vanishing so suddenly: you do 1 quite giddy.'
 
-'All flop,' said the Cat; and this time it vanished quite slow,
+'All flop,' say the Cat; and this time it fly quite slow,
 root with the end of the tail, and ending with the grin, which
-remained some time after the rest of it had gone.
+remain some time after the rest of it had go.
 
-'Well! I've often seen a cat without a grin,' thought Alice; 'but a grin
+'Well! I've often see a cat without a grin,' thought Alice; 'but a grin
 without a cat! It's the most odd thing I ever saw in my life!'
 
-She had not gone much farther before she came in ken of the house
+She had not go much farther before she came in ken of the house
 of the Mar Hare: she thought it must be the flop house, because the
-chimneys were shaped ilk ears and the roof was thatched with fur. It
-was so big a house, that she did not ilk to go nearer till she had
-nibbled some more of the lefthand bit of mushroom, and raised herself to
-most 2 feet high: yet so she walked up towards it kinda timidly,
+chimney be form ilk ear and the roof was thatch with fur. It
+was so big a house, that she do not ilk to go near till she had
+pick some more of the lefthand bit of mushroom, and lift herself to
+most 2 ft high: yet so she walk up towards it kinda timidly,
 saying to herself 'Suppose it should be raving mad after all! I almost
-bid I'd gone to see the Hatter instead!'
+bid I'd go to see the Hatter instead!'
 
 
 
@@ -1571,91 +1571,91 @@ bid I'd gone to see the Hatter instead!'
 CHAPTER VII. A Mad Tea-Party
 
 There was a table set out under a tree in look of the house, and the
-Mar Hare and the Hatter were having tea at it: a Dormouse was posing
-'tween them, fast numb, and the other 2 were using it as a
-buffer, resting their elbows on it, and talking over its head. 'Very
+Mar Hare and the Hatter be get tea at it: a Dormouse was posing
+'tween them, fast numb, and the other 2 be using it as a
+buffer, rest their elbow on it, and talking over its head. 'Very
 uncomfortable for the Dormouse,' thought Alice; 'only, as it's numb, I
 say it doesn't mind.'
 
-The table was a big 1, but the 3 were all crowded together at
-1 box of it: 'No way! No way!' they cried out when they saw Alice
-coming. 'There's PLENTY of way!' said Alice indignantly, and she sat
+The table was a big 1, but the 3 be all crowd together at
+1 box of it: 'No way! No way!' they cry out when they saw Alice
+coming. 'There's PLENTY of way!' say Alice indignantly, and she sat
 down in a big arm-chair at 1 end of the table.
 
-'Have some wine,' the Mar Hare said in an supporting tone.
+'Have some wine,' the Mar Hare say in an encourage tone.
 
-Alice looked all round the table, but there was nil on it but tea.
+Alice look all round the table, but there was nil on it but tea.
 'I don't see any wine,' she remarked.
 
-'There isn't any,' said the Mar Hare.
+'There isn't any,' say the Mar Hare.
 
-'Then it wasn't very civil of you to bid it,' said Alice angrily.
+'Then it wasn't very civil of you to bid it,' say Alice angrily.
 
-'It wasn't very civil of you to sit down without being invited,' said
+'It wasn't very civil of you to sit down without being bid,' say
 the Mar Hare.
 
-'I didn't know it was YOUR table,' said Alice; 'it's set for a great
+'I didn't know it was YOUR table,' say Alice; 'it's lay for a great
 many more than 3.'
 
-'Your hair wants slip,' said the Hatter. He had been looking at Alice
+'Your hair want slip,' say the Hatter. He had be looking at Alice
 for some time with great wonder, and this was his 1st speech.
 
-'You should see not to do personal remarks,' Alice said with some
+'You should see not to do personal input,' Alice say with some
 rigor; 'it's very rude.'
 
-The Hatter opened his eyes very wide on hearing this; but all he SAID
+The Hatter open his eyes very wide on hearing this; but all he SAID
 was, 'Why is a prey ilk a writing-desk?'
 
 'Come, we shall get some fun now!' thought Alice. 'I'm glad they've
-begun asking riddles.--I trust I can shot that,' she added aloud.
+begun asking riddles.--I trust I can shot that,' she add aloud.
 
-'Do you mean that you think you can find out the reply to it?' said the
+'Do you mean that you think you can find out the reply to it?' say the
 Mar Hare.
 
-'Exactly so,' said Alice.
+'Exactly so,' say Alice.
 
-'Then you should say what you mean,' the Mar Hare went on.
+'Then you should say what you mean,' the Mar Hare go on.
 
 'I do,' Alice hastily replied; 'at least--at least I mean what I
 say--that's the same thing, you know.'
 
-'Not the same thing a bit!' said the Hatter. 'You might just as well say
+'Not the same thing a bit!' say the Hatter. 'You might just as well say
 that "I see what I eat" is the same thing as "I eat what I see"!'
 
-'You might just as well say,' added the Mar Hare, 'that "I ilk what I
+'You might just as well say,' add the Mar Hare, 'that "I ilk what I
 get" is the same thing as "I get what I ilk"!'
 
-'You might just as well say,' added the Dormouse, who seemed to be
+'You might just as well say,' add the Dormouse, who seem to be
 talking in his nap, 'that "I breathe when I nap" is the same thing
 as "I nap when I breathe"!'
 
-'It IS the same thing with you,' said the Hatter, and here the
-conversation dropped, and the party sat still for a min, while Alice
-thought over all she could think most ravens and writing-desks,
+'It IS the same thing with you,' say the Hatter, and here the
+conversation drop, and the party sat still for a min, while Alice
+thought over all she could think most prey and writing-desks,
 which wasn't much.
 
 The Hatter was the 1st to gap the quiet. 'What day of the month
-is it?' he said, turn to Alice: he had taken his see out of his
+is it?' he say, turn to Alice: he had take his see out of his
 bag, and was looking at it uneasily, quiver it every now and so,
 and holding it to his ear.
 
-Alice considered a small, and so said 'The 4th.'
+Alice take a small, and so say 'The 4th.'
 
-'Two days wrong!' sighed the Hatter. 'I told you butter wouldn't fit
-the works!' he added looking angrily at the Mar Hare.
+'Two days wrong!' sigh the Hatter. 'I told you butter wouldn't fit
+the works!' he add looking angrily at the Mar Hare.
 
 'It was the BEST butter,' the Mar Hare meekly replied.
 
-'Yes, but some crumbs must get got in as well,' the Hatter grumbled:
+'Yes, but some crumb must get got in as well,' the Hatter growl:
 'you shouldn't get put it in with the bread-knife.'
 
-The Mar Hare took the see and looked at it gloomily: so he dipped
-it into his cup of tea, and looked at it again: but he could think of
+The Mar Hare took the see and look at it gloomily: so he dip
+it into his cup of tea, and look at it again: but he could think of
 nil best to say than his 1st input, 'It was the BEST butter,
 you know.'
 
-Alice had been looking over his berm with some wonder. 'What a
-funny see!' she remarked. 'It tells the day of the month, and doesn't
+Alice had be looking over his berm with some wonder. 'What a
+funny see!' she remarked. 'It tell the day of the month, and doesn't
 tell what o'clock it is!'
 
 'Why should it?' muttered the Hatter. 'Does YOUR see tell you what
@@ -1664,60 +1664,60 @@ yr it is?'
 'Of row not,' Alice replied very readily: 'but that's because it
 stays the same yr for such a long time together.'
 
-'Which is just the case with MINE,' said the Hatter.
+'Which is just the case with MINE,' say the Hatter.
 
-Alice mat awfully puzzled. The Hatter's input seemed to get no
+Alice mat awfully puzzle. The Hatter's input seem to get no
 sort of import in it, and yet it was certainly side. 'I don't quite
-see you,' she said, as politely as she could.
+see you,' she say, as politely as she could.
 
-'The Dormouse is numb again,' said the Hatter, and he poured a small
+'The Dormouse is numb again,' say the Hatter, and he pour a small
 hot tea upon its nose.
 
-The Dormouse shook its head impatiently, and said, without gap its
+The Dormouse shook its head impatiently, and say, without gap its
 eyes, 'Of row, of row; just what I was going to input myself.'
 
-'Have you guessed the riddle yet?' the Hatter said, turn to Alice
+'Have you guess the riddle yet?' the Hatter say, turn to Alice
 again.
 
 'No, I pay it up,' Alice replied: 'what's the reply?'
 
-'I haven't the slightest idea,' said the Hatter.
+'I haven't the slightest idea,' say the Hatter.
 
-'Nor I,' said the Mar Hare.
+'Nor I,' say the Mar Hare.
 
-Alice sighed wearily. 'I think you might do something best with the
-time,' she said, 'than rot it in asking riddles that get no answers.'
+Alice sigh wearily. 'I think you might do something best with the
+time,' she say, 'than rot it in asking riddle that get no reply.'
 
-'If you knew Time as well as I do,' said the Hatter, 'you wouldn't talk
+'If you knew Time as well as I do,' say the Hatter, 'you wouldn't talk
 most wasting IT. It's HIM.'
 
-'I don't know what you mean,' said Alice.
+'I don't know what you mean,' say Alice.
 
-'Of row you don't!' the Hatter said, tossing his head scornfully.
+'Of row you don't!' the Hatter say, toss his head scornfully.
 'I dare say you never yet spoke to Time!'
 
 'Perhaps not,' Alice carefully replied: 'but I know I get to beat time
 when I see music.'
 
-'Ah! that accounts for it,' said the Hatter. 'He won't stand lacing.
+'Ah! that account for it,' say the Hatter. 'He won't stand lacing.
 Now, if you only kept on good terms with him, he'd do almost anything
-you liked with the time. For instance, say it were 9 o'clock in
-the morn, just time to begin lessons: you'd only get to whisper a
-hint to Time, and round goes the time in a twinkling! Half-past 1,
+you like with the time. For instance, say it be 9 o'clock in
+the morn, just time to begin lesson: you'd only get to whisper a
+hint to Time, and round go the time in a twinkling! Half-past 1,
 time for dinner!'
 
-('I only bid it was,' the Mar Hare said to itself in a whisper.)
+('I only bid it was,' the Mar Hare say to itself in a whisper.)
 
-'That would be grand, certainly,' said Alice thoughtfully: 'but then--I
+'That would be grand, certainly,' say Alice thoughtfully: 'but then--I
 shouldn't be hungry for it, you know.'
 
-'Not at 1st, perhaps,' said the Hatter: 'but you could keep it to
-half-past 1 as long as you liked.'
+'Not at 1st, perhaps,' say the Hatter: 'but you could keep it to
+half-past 1 as long as you like.'
 
-'Is that the way YOU deal?' Alice asked.
+'Is that the way YOU deal?' Alice ask.
 
 The Hatter shook his head mournfully. 'Not I!' he replied. 'We
-quarrelled last March--just before HE went mad, you know--' (pointing
+scrap last March--just before HE go mad, you know--' (point
 with his tea spoon at the Mar Hare,) '--it was at the great concert
 given by the Queen of Hearts, and I had to sing
 
@@ -1726,366 +1726,366 @@ given by the Queen of Hearts, and I had to sing
 
 You know the song, perhaps?'
 
-'I've heard something ilk it,' said Alice.
+'I've try something ilk it,' say Alice.
 
-'It goes on, you know,' the Hatter continued, 'in this way:--
+'It go on, you know,' the Hatter keep, 'in this way:--
 
      "Up above the man you fly,
      Like a tea-tray in the sky.
          Twinkle, winkle--"'
 
 Here the Dormouse shook itself, and began singing in its nap 'Twinkle,
-winkle, winkle, winkle--' and went on so long that they had to nip
+winkle, winkle, winkle--' and go on so long that they had to nip
 it to do it stop.
 
-'Well, I'd hardly ruined the 1st verse,' said the Hatter, 'when the
-Queen jumped up and bawled out, "He's murdering the time! Off with his
+'Well, I'd hardly finish the 1st verse,' say the Hatter, 'when the
+Queen jump up and bawl out, "He's hit the time! Off with his
 head!"'
 
-'How awfully blast!' exclaimed Alice.
+'How awfully blast!' cry Alice.
 
-'And ever since that,' the Hatter went on in a mournful tone, 'he won't
+'And ever since that,' the Hatter go on in a mournful tone, 'he won't
 do a thing I ask! It's ever 6 o'clock now.'
 
 A vivid idea came into Alice's head. 'Is that the reason so many
-tea-things ar put out here?' she asked.
+tea-things ar put out here?' she ask.
 
-'Yes, that's it,' said the Hatter with a sigh: 'it's ever tea-time,
-and we've no time to wash the things 'tween whiles.'
+'Yes, that's it,' say the Hatter with a sigh: 'it's ever tea-time,
+and we've no time to wash the things 'tween while.'
 
-'Then you keep moving round, I say?' said Alice.
+'Then you keep go round, I say?' say Alice.
 
-'Exactly so,' said the Hatter: 'as the things get used up.'
+'Exactly so,' say the Hatter: 'as the things get use up.'
 
-'But what happens when you come to the root again?' Alice ventured
+'But what hap when you come to the root again?' Alice stake
 to ask.
 
-'Suppose we vary the case,' the Mar Hare interrupted, yawning.
-'I'm getting tired of this. I vote the young lady tells us a story.'
+'Suppose we vary the case,' the Mar Hare break, yawning.
+'I'm getting fag of this. I vote the young lady tell us a story.'
 
-'I'm afraid I don't know 1,' said Alice, kinda alarmed at the
+'I'm afraid I don't know 1,' say Alice, kinda alarm at the
 proposal.
 
-'Then the Dormouse shall!' they both cried. 'Wake up, Dormouse!' And
-they pinched it on both sides at once.
+'Then the Dormouse shall!' they both cry. 'Wake up, Dormouse!' And
+they nip it on both side at once.
 
-The Dormouse slow opened his eyes. 'I wasn't numb,' he said in a
-hoarse, lame vox: 'I heard every word you fellows were saying.'
+The Dormouse slow open his eyes. 'I wasn't numb,' he say in a
+hoarse, lame vox: 'I try every word you dude be saying.'
 
-'Tell us a story!' said the Mar Hare.
+'Tell us a story!' say the Mar Hare.
 
-'Yes, please do!' pleaded Alice.
+'Yes, please do!' plead Alice.
 
-'And be warm most it,' added the Hatter, 'or you'll be numb again
-before it's done.'
+'And be warm most it,' add the Hatter, 'or you'll be numb again
+before it's do.'
 
-'Once upon a time there were 3 small sisters,' the Dormouse began
-in a great hurry; 'and their names were Elsie, Lacie, and Tillie; and
-they lived at the bottom of a well--'
+'Once upon a time there be 3 small sis,' the Dormouse began
+in a great hurry; 'and their names be Elsie, Lacie, and Tillie; and
+they live at the bottom of a well--'
 
-'What did they live on?' said Alice, who ever took a great stake in
-questions of eating and drinking.
+'What do they live on?' say Alice, who ever took a great stake in
+head of eating and drinking.
 
-'They lived on mush,' said the Dormouse, after thought a min or
+'They live on mush,' say the Dormouse, after thought a min or
 2.
 
-'They couldn't get done that, you know,' Alice gently remarked; 'they'd
-get been ill.'
+'They couldn't get do that, you know,' Alice gently remarked; 'they'd
+get be ill.'
 
-'So they were,' said the Dormouse; 'VERY ill.'
+'So they be,' say the Dormouse; 'VERY ill.'
 
-Alice tried to fancy to herself what such an sinful ways of
-living would be ilk, but it puzzled her too much, so she went on: 'But
-why did they live at the bottom of a well?'
+Alice try to fancy to herself what such an sinful ways of
+living would be ilk, but it puzzle her too much, so she go on: 'But
+why do they live at the bottom of a well?'
 
-'Take some more tea,' the Mar Hare said to Alice, very earnestly.
+'Take some more tea,' the Mar Hare say to Alice, very earnestly.
 
 'I've had nil yet,' Alice replied in an pained tone, 'so I can't
 take more.'
 
-'You mean you can't take LESS,' said the Hatter: 'it's very easy to take
+'You mean you can't take LESS,' say the Hatter: 'it's very easy to take
 MORE than nil.'
 
-'Nobody asked YOUR view,' said Alice.
+'Nobody ask YOUR view,' say Alice.
 
-'Who's making personal remarks now?' the Hatter asked triumphantly.
+'Who's making personal input now?' the Hatter ask triumphantly.
 
-Alice did not quite know what to say to this: so she helped herself
-to some tea and bread-and-butter, and so turned to the Dormouse, and
-repeated her head. 'Why did they live at the bottom of a well?'
+Alice do not quite know what to say to this: so she aid herself
+to some tea and bread-and-butter, and so turn to the Dormouse, and
+echo her head. 'Why do they live at the bottom of a well?'
 
 The Dormouse again took a min or 2 to think most it, and so
-said, 'It was a treacle-well.'
+say, 'It was a treacle-well.'
 
 'There's no such thing!' Alice was root very angrily, but the
-Hatter and the Mar Hare went 'Sh! sh!' and the Dormouse sulkily
+Hatter and the Mar Hare go 'Sh! sh!' and the Dormouse sulkily
 remarked, 'If you can't be civil, you'd best goal the story for
 yourself.'
 
-'No, please go on!' Alice said very humbly; 'I won't break again. I
+'No, please go on!' Alice say very humbly; 'I won't break again. I
 dare say there may be ONE.'
 
-'One, so!' said the Dormouse indignantly. However, he consented to
-go on. 'And so these 3 small sisters--they were learning to tie,
+'One, so!' say the Dormouse indignantly. However, he consented to
+go on. 'And so these 3 small sisters--they be learning to tie,
 you know--'
 
-'What did they tie?' said Alice, quite forgetting her hope.
+'What do they tie?' say Alice, quite bury her hope.
 
-'Treacle,' said the Dormouse, without considering at all this time.
+'Treacle,' say the Dormouse, without take at all this time.
 
-'I want a pick cup,' interrupted the Hatter: 'let's all go 1 put
+'I want a pick cup,' break the Hatter: 'let's all go 1 put
 on.'
 
-He moved on as he spoke, and the Dormouse followed him: the Mar Hare
-moved into the Dormouse's put, and Alice kinda unwillingly took
+He go on as he spoke, and the Dormouse follow him: the Mar Hare
+go into the Dormouse's put, and Alice kinda unwillingly took
 the put of the Mar Hare. The Hatter was the only 1 who got any
 reward from the vary: and Alice was a good deal worse off than
 before, as the Mar Hare had just upset the milk-jug into his plate.
 
-Alice did not bid to offend the Dormouse again, so she began very
-carefully: 'But I don't see. Where did they tie the mush
+Alice do not bid to offend the Dormouse again, so she began very
+carefully: 'But I don't see. Where do they tie the mush
 from?'
 
-'You can tie H2O out of a water-well,' said the Hatter; 'so I should
+'You can tie H2O out of a water-well,' say the Hatter; 'so I should
 think you could tie mush out of a treacle-well--eh, dolt?'
 
-'But they were IN the well,' Alice said to the Dormouse, not choosing to
+'But they be IN the well,' Alice say to the Dormouse, not opt to
 mark this last input.
 
-'Of row they were', said the Dormouse; '--well in.'
+'Of row they be', say the Dormouse; '--well in.'
 
-This reply so lost poor Alice, that she let the Dormouse go on for
-some time without interrupting it.
+This reply so fox poor Alice, that she let the Dormouse go on for
+some time without break it.
 
-'They were learning to tie,' the Dormouse went on, yawning and rubbing
+'They be learning to tie,' the Dormouse go on, yawning and rubbing
 its eyes, for it was getting very sleepy; 'and they drew all way of
-things--everything that begins with an M--'
+things--everything that begin with an M--'
 
-'Why with an M?' said Alice.
+'Why with an M?' say Alice.
 
-'Why not?' said the Mar Hare.
+'Why not?' say the Mar Hare.
 
 Alice was still.
 
 The Dormouse had shut its eyes by this time, and was going off into
-a doze; but, on being pinched by the Hatter, it woke up again with
-a small pipe, and went on: '--that begins with an M, such as
+a doze; but, on being nip by the Hatter, it woke up again with
+a small pipe, and go on: '--that begin with an M, such as
 mouse-traps, and the moon, and store, and muchness--you know you say
-things ar "much of a muchness"--did you ever see such a thing as a
+things ar "much of a muchness"--do you ever see such a thing as a
 drawing of a muchness?'
 
-'Really, now you ask me,' said Alice, very much lost, 'I don't
+'Really, now you ask me,' say Alice, very much fox, 'I don't
 think--'
 
-'Then you shouldn't talk,' said the Hatter.
+'Then you shouldn't talk,' say the Hatter.
 
 This bit of rudeness was more than Alice could bear: she got up in
-great repel, and walked off; the Dormouse fell numb instantly, and
+great repel, and walk off; the Dormouse fell numb instantly, and
 neither of the others took the least mark of her going, though she
-looked back once or twice, half hoping that they would call after her:
-the last time she saw them, they were trying to put the Dormouse into
+look back once or twice, half hope that they would call after her:
+the last time she saw them, they be try to put the Dormouse into
 the teapot.
 
-'At any rate I'll never go THERE again!' said Alice as she picked her
-way through the wood. 'It's the stupidest tea-party I ever was at in all
+'At any rate I'll never go THERE again!' say Alice as she pick her
+way through the wood. 'It's the stupid tea-party I ever was at in all
 my life!'
 
-Just as she said this, she noticed that 1 of the trees had a door
+Just as she say this, she mark that 1 of the tree had a door
 star flop into it. 'That's very odd!' she thought. 'But
 everything's odd today. I think I may as well go in at once.' And in
-she went.
+she go.
 
 Once more she found herself in the long hall, and shut to the small
-glass table. 'Now, I'll deal best this time,' she said to herself,
-and began by taking the small lucky key, and unlocking the door that
-led into the garden. Then she went to act nibbling at the mushroom (she
+glass table. 'Now, I'll deal best this time,' she say to herself,
+and began by taking the small lucky key, and unlock the door that
+led into the garden. Then she go to act pick at the mushroom (she
 had kept a bit of it in her bag) till she was most a ft high:
-so she walked down the small passage: and THEN--she found herself at
+so she walk down the small passage: and THEN--she found herself at
 last in the beautiful garden, among the vivid flower-beds and the cool
-fountains.
+jet.
 
 
 
 
 CHAPTER VIII. The Queen's Croquet-Ground
 
-A big rose-tree stood near the entry of the garden: the roses
-growing on it were white, but there were 3 gardeners at it, busily
-picture them red. Alice thought this a very odd thing, and she went
-nearer to see them, and just as she came up to them she heard 1 of
+A big rose-tree stood near the entry of the garden: the rose
+growing on it be white, but there be 3 gardener at it, busily
+picture them red. Alice thought this a very odd thing, and she go
+near to see them, and just as she came up to them she try 1 of
 them say, 'Look out now, Five! Don't go splashing paint over me ilk
 that!'
 
-'I couldn't aid it,' said Five, in a sulky tone; 'Seven jogged my
+'I couldn't aid it,' say Five, in a sulky tone; 'Seven jog my
 elbow.'
 
-On which Seven looked up and said, 'That's flop, Five! Always lay the
+On which Seven look up and say, 'That's flop, Five! Always lay the
 rap on others!'
 
-'YOU'D best not talk!' said Five. 'I heard the Queen say only
-yesterday you deserved to be beheaded!'
+'YOU'D best not talk!' say Five. 'I try the Queen say only
+yesterday you merit to be beheaded!'
 
-'What for?' said the 1 who had spoken 1st.
+'What for?' say the 1 who had talk 1st.
 
-'That's none of YOUR byplay, Two!' said Seven.
+'That's none of YOUR byplay, Two!' say Seven.
 
-'Yes, it IS his byplay!' said Five, 'and I'll tell him--it was for
-bringing the fix tulip-roots instead of onions.'
+'Yes, it IS his byplay!' say Five, 'and I'll tell him--it was for
+bringing the fix tulip-roots instead of onion.'
 
 Seven flung down his brush, and had just begun 'Well, of all the unjust
-things--' when his eye chanced to pin upon Alice, as she stood watching
-them, and he checked himself suddenly: the others looked round also, and
-all of them bowed low.
+things--' when his eye chance to pin upon Alice, as she stood watching
+them, and he mark himself suddenly: the others look round also, and
+all of them bow low.
 
-'Would you tell me,' said Alice, a small timidly, 'why you ar picture
-those roses?'
+'Would you tell me,' say Alice, a small timidly, 'why you ar picture
+those rose?'
 
-Five and Seven said nil, but looked at Two. Two began in a low
-vox, 'Why the fact is, you see, Miss, this here ought to get been a
+Five and Seven say nil, but look at Two. Two began in a low
+vox, 'Why the fact is, you see, Miss, this here ought to get be a
 RED rose-tree, and we put a white 1 in by error; and if the Queen
-was to find it out, we should all get our heads cut off, you know.
-So you see, Miss, we're doing our best, afore she comes, to--' At this
-mo Five, who had been uneasily looking across the garden, called
-out 'The Queen! The Queen!' and the 3 gardeners instantly threw
-themselves mat upon their faces. There was a go of many footsteps,
-and Alice looked round, eager to see the Queen.
+was to find it out, we should all get our head cut off, you know.
+So you see, Miss, we're do our best, afore she come, to--' At this
+mo Five, who had be uneasily looking across the garden, call
+out 'The Queen! The Queen!' and the 3 gardener instantly flip
+themselves mat upon their face. There was a go of many pace,
+and Alice look round, eager to see the Queen.
 
-First came X soldiers carrying clubs; these were all shaped ilk
-the 3 gardeners, oblong and mat, with their hands and feet at the
-corners: next the X courtiers; these were ornamented all over with
-diamonds, and walked 2 and 2, as the soldiers did. After these came
-the royal children; there were X of them, and the small dears came
-jumping merrily on paw in paw, in couples: they were all ornamented
-with hearts. Next came the guests, mostly Kings and Queens, and among
+First came X soldier run club; these be all form ilk
+the 3 gardener, oblong and mat, with their hands and ft at the
+box: next the X courtier; these be ornament all over with
+diamond, and walk 2 and 2, as the soldier do. After these came
+the royal kid; there be X of them, and the small dears came
+jumping merrily on paw in paw, in duo: they be all ornament
+with hearts. Next came the guest, mostly Kings and Queens, and among
 them Alice recognised the White Rabbit: it was talking in a hurried
-neural way, smiling at everything that was said, and went by without
-noticing her. Then followed the Knave of Hearts, carrying the King's
+neural way, smiling at everything that was say, and go by without
+mark her. Then follow the Knave of Hearts, run the King's
 cap on a red velvet buffer; and, last of all this grand
 procession, came THE KING AND QUEEN OF HEARTS.
 
 Alice was kinda dubious whether she ought not to lie down on her face
-ilk the 3 gardeners, but she could not think ever having heard
-of such a rule at processions; 'and too, what would be the use of
+ilk the 3 gardener, but she could not think ever get try
+of such a rule at procession; 'and too, what would be the use of
 a procession,' thought she, 'if people had all to lie down upon their
-faces, so that they couldn't see it?' So she stood ease where she was,
-and waited.
+face, so that they couldn't see it?' So she stood ease where she was,
+and wait.
 
-When the procession came paired to Alice, they all stopped and looked
-at her, and the Queen said severely 'Who is this?' She said it to the
-Knave of Hearts, who only bowed and smiled in reply.
+When the procession came paired to Alice, they all stop and look
+at her, and the Queen say severely 'Who is this?' She say it to the
+Knave of Hearts, who only bow and smile in reply.
 
-'Idiot!' said the Queen, tossing her head impatiently; and, turn to
-Alice, she went on, 'What's your name, kid?'
+'Idiot!' say the Queen, toss her head impatiently; and, turn to
+Alice, she go on, 'What's your name, kid?'
 
-'My name is Alice, so please your Majesty,' said Alice very politely;
-but she added, to herself, 'Why, they're only a wad of cards, after
+'My name is Alice, so please your Majesty,' say Alice very politely;
+but she add, to herself, 'Why, they're only a wad of cards, after
 all. I needn't be afraid of them!'
 
-'And who ar THESE?' said the Queen, pointing to the 3 gardeners who
-were lying round the rosetree; for, you see, as they were lying on their
-faces, and the pattern on their backs was the same as the rest of the
-wad, she could not tell whether they were gardeners, or soldiers, or
-courtiers, or 3 of her own children.
+'And who ar THESE?' say the Queen, point to the 3 gardener who
+be lying round the rosetree; for, you see, as they be lying on their
+face, and the pattern on their back was the same as the rest of the
+wad, she could not tell whether they be gardener, or soldier, or
+courtier, or 3 of her own kid.
 
-'How should I know?' said Alice, surprised at her own courage. 'It's no
+'How should I know?' say Alice, surprise at her own courage. 'It's no
 byplay of MINE.'
 
-The Queen turned red with fury, and, after glaring at her for a
-mo ilk a wild wolf, screamed 'Off with her head! Off--'
+The Queen turn red with fury, and, after glare at her for a
+mo ilk a wild wolf, scream 'Off with her head! Off--'
 
-'Nonsense!' said Alice, very loud and decidedly, and the Queen was
+'Nonsense!' say Alice, very loud and decidedly, and the Queen was
 still.
 
-The King set his paw upon her arm, and timidly said 'Consider, my
+The King lay his paw upon her arm, and timidly say 'Consider, my
 dear: she is only a kid!'
 
-The Queen turned angrily off from him, and said to the Knave 'Turn them
+The Queen turn angrily off from him, and say to the Knave 'Turn them
 over!'
 
-The Knave did so, very carefully, with 1 ft.
+The Knave do so, very carefully, with 1 ft.
 
-'Get up!' said the Queen, in a sharp, loud vox, and the 3
-gardeners instantly jumped up, and began bowing to the King, the Queen,
-the royal children, and everybody else.
+'Get up!' say the Queen, in a sharp, loud vox, and the 3
+gardener instantly jump up, and began bowing to the King, the Queen,
+the royal kid, and everybody else.
 
-'Leave off that!' screamed the Queen. 'You do me giddy.' And so,
-turn to the rose-tree, she went on, 'What HAVE you been doing here?'
+'Leave off that!' scream the Queen. 'You do me giddy.' And so,
+turn to the rose-tree, she go on, 'What HAVE you be do here?'
 
-'May it please your Majesty,' said Two, in a very low tone, going
-down on 1 knee as he spoke, 'we were trying--'
+'May it please your Majesty,' say Two, in a very low tone, going
+down on 1 knee as he spoke, 'we be try--'
 
-'I see!' said the Queen, who had meantime been examining the roses.
-'Off with their heads!' and the procession moved on, 3 of the
-soldiers remaining slow to execute the unfortunate gardeners, who ran
+'I see!' say the Queen, who had meantime be see the rose.
+'Off with their head!' and the procession go on, 3 of the
+soldier remain slow to execute the unfortunate gardener, who go
 to Alice for shelter.
 
-'You shan't be beheaded!' said Alice, and she put them into a big
-flower-pot that stood near. The 3 soldiers wandered most for a
-min or 2, looking for them, and so quiet marched off after the
+'You shan't be beheaded!' say Alice, and she put them into a big
+flower-pot that stood near. The 3 soldier wander most for a
+min or 2, looking for them, and so quiet march off after the
 others.
 
-'Are their heads off?' yelled the Queen.
+'Are their head off?' cry the Queen.
 
-'Their heads ar gone, if it please your Majesty!' the soldiers yelled
+'Their head ar go, if it please your Majesty!' the soldier cry
 in reply.
 
-'That's flop!' yelled the Queen. 'Can you toy croquet?'
+'That's flop!' cry the Queen. 'Can you toy croquet?'
 
-The soldiers were still, and looked at Alice, as the head was
-evidently meant for her.
+The soldier be still, and look at Alice, as the head was
+evidently mean for her.
 
-'Yes!' yelled Alice.
+'Yes!' cry Alice.
 
-'Come on, so!' roared the Queen, and Alice joined the procession,
-wondering very much what would hap next.
+'Come on, so!' roar the Queen, and Alice join the procession,
+wonder very much what would hap next.
 
-'It's--it's a very fine day!' said a timid vox at her side. She was
-walking by the White Rabbit, who was peeping uneasily into her face.
+'It's--it's a very fine day!' say a timid vox at her side. She was
+walking by the White Rabbit, who was peep uneasily into her face.
 
-'Very,' said Alice: '--where's the Duchess?'
+'Very,' say Alice: '--where's the Duchess?'
 
-'Hush! Hush!' said the Rabbit in a low, hurried tone. He looked
-uneasily over his berm as he spoke, and so raised himself upon
-tip, put his mouth shut to her ear, and whispered 'She's under
+'Hush! Hush!' say the Rabbit in a low, hurried tone. He look
+uneasily over his berm as he spoke, and so lift himself upon
+tip, put his mouth shut to her ear, and whisper 'She's under
 doom of execution.'
 
-'What for?' said Alice.
+'What for?' say Alice.
 
-'Did you say "What a pity!"?' the Rabbit asked.
+'Did you say "What a pity!"?' the Rabbit ask.
 
-'No, I didn't,' said Alice: 'I don't think it's at all a pity. I said
+'No, I didn't,' say Alice: 'I don't think it's at all a pity. I say
 "What for?"'
 
-'She boxed the Queen's ears--' the Rabbit began. Alice gave a small
-scream of laughter. 'Oh, hush!' the Rabbit whispered in a scared
+'She box the Queen's ear--' the Rabbit began. Alice pay a small
+scream of laughter. 'Oh, hush!' the Rabbit whisper in a scare
 tone. 'The Queen will try you! You see, she came kinda late, and the
-Queen said--'
+Queen say--'
 
-'Get to your places!' yelled the Queen in a vox of roar, and
-people began running most in all directions, tumbling up against each
-other; yet, they got settled down in a min or 2, and the biz
-began. Alice thought she had never seen such a odd croquet-ground in
-her life; it was all ridges and furrows; the balls were live hedgehogs,
-the mallets live flamingoes, and the soldiers had to dual themselves
-up and to stand on their hands and feet, to do the arches.
+'Get to your put!' cry the Queen in a vox of roar, and
+people began running most in all way, tumbling up against each
+other; yet, they got root down in a min or 2, and the biz
+began. Alice thought she had never see such a odd croquet-ground in
+her life; it was all ridge and rut; the orb be live hedgehog,
+the mallet live flamingo, and the soldier had to dual themselves
+up and to stand on their hands and ft, to do the arc.
 
-The main difficulty Alice found at 1st was in managing her flamingo:
-she succeeded in getting its body tucked off, comfortably enough, under
+The main difficulty Alice found at 1st was in deal her flamingo:
+she win in getting its body tuck off, comfortably enough, under
 her arm, with its legs hanging down, but generally, just as she had got
-its neck nicely straightened out, and was going to pay the hedgehog a
+its neck nicely unbend out, and was going to pay the hedgehog a
 blow with its head, it WOULD turn itself round and look up in her face,
-with such a puzzled look that she could not aid bursting out
-riant: and when she had got its head down, and was going to begin
-again, it was very provoking to find that the hedgehog had unrolled
+with such a puzzle look that she could not aid bust out
+laugh: and when she had got its head down, and was going to begin
+again, it was very evoke to find that the hedgehog had unrolled
 itself, and was in the do of crawling off: too all this, there was
-generally a ridge or rut in the way wherever she wanted to send the
-hedgehog to, and, as the doubled-up soldiers were ever getting up
+generally a ridge or rut in the way wherever she want to send the
+hedgehog to, and, as the doubled-up soldier be ever getting up
 and walking off to other parts of the earth, Alice soon came to the
 end that it was a very hard biz so.
 
-The players all played at once without waiting for turns, quarrelling
-all the while, and fighting for the hedgehogs; and in a very short
-time the Queen was in a furious passion, and went stamping most, and
+The player all toy at once without waiting for turn, scrap
+all the while, and fighting for the hedgehog; and in a very short
+time the Queen was in a furious passion, and go stamp most, and
 shouting 'Off with his head!' or 'Off with her head!' most once in a
 min.
 
@@ -2095,95 +2095,95 @@ dispute with the Queen, but she knew that it might hap any min,
 fond of beheading people here; the great wonder is, that there's any 1
 left live!'
 
-She was looking most for some way of leak, and wondering whether she
-could get off without being seen, when she noticed a odd show
-in the air: it puzzled her very much at 1st, but, after watching it
-a min or 2, she made it out to be a grin, and she said to herself
+She was looking most for some way of leak, and wonder whether she
+could get off without being see, when she mark a odd show
+in the air: it puzzle her very much at 1st, but, after watching it
+a min or 2, she do it out to be a grin, and she say to herself
 'It's the Cheshire Cat: now I shall get somebody to talk to.'
 
-'How ar you getting on?' said the Cat, as soon as there was mouth
+'How ar you getting on?' say the Cat, as soon as there was mouth
 enough for it to talk with.
 
-Alice waited till the eyes appeared, and so nodded. 'It's no use
-speaking to it,' she thought, 'till its ears get come, or at least 1
-of them.' In another min the unit head appeared, and so Alice put
+Alice wait till the eyes seem, and so nod. 'It's no use
+speaking to it,' she thought, 'till its ear get come, or at least 1
+of them.' In another min the unit head seem, and so Alice put
 down her flamingo, and began an account of the biz, feeling very glad
-she had someone to hear to her. The Cat seemed to think that there was
-enough of it now in ken, and no more of it appeared.
+she had someone to hear to her. The Cat seem to think that there was
+enough of it now in ken, and no more of it seem.
 
 'I don't think they toy at all fair,' Alice began, in kinda a
-complaining tone, 'and they all row so awfully 1 can't try
-oneself speak--and they don't seem to get any rules in special;
-at least, if there ar, nobody attends to them--and you've no idea how
-puzzling it is all the things being live; for instance, there's the
+kick tone, 'and they all row so awfully 1 can't try
+oneself speak--and they don't seem to get any rule in special;
+at least, if there ar, nobody see to them--and you've no idea how
+fox it is all the things being live; for instance, there's the
 arc I've got to go through next walking most at the other end of the
-ground--and I should get croqueted the Queen's hedgehog just now, only
-it ran off when it saw mine coming!'
+ground--and I should get croquet the Queen's hedgehog just now, only
+it go off when it saw mine coming!'
 
-'How do you ilk the Queen?' said the Cat in a low vox.
+'How do you ilk the Queen?' say the Cat in a low vox.
 
-'Not at all,' said Alice: 'she's so super--' Just so she noticed
-that the Queen was shut slow her, hearing: so she went on,
+'Not at all,' say Alice: 'she's so super--' Just so she mark
+that the Queen was shut slow her, hearing: so she go on,
 '--likely to win, that it's hardly worth while finishing the biz.'
 
-The Queen smiled and passed on.
+The Queen smile and pass on.
 
-'Who ARE you talking to?' said the King, going up to Alice, and looking
+'Who ARE you talking to?' say the King, going up to Alice, and looking
 at the Cat's head with great wonder.
 
-'It's a friend of mine--a Cheshire Cat,' said Alice: 'allow me to
+'It's a friend of mine--a Cheshire Cat,' say Alice: 'allow me to
 present it.'
 
-'I don't ilk the look of it at all,' said the King: 'yet, it may
-kiss my paw if it likes.'
+'I don't ilk the look of it at all,' say the King: 'yet, it may
+kiss my paw if it ilk.'
 
 'I'd kinda not,' the Cat remarked.
 
-'Don't be pert,' said the King, 'and don't look at me ilk that!'
+'Don't be pert,' say the King, 'and don't look at me ilk that!'
 He got slow Alice as he spoke.
 
-'A cat may look at a Rex,' said Alice. 'I've say that in some book,
+'A cat may look at a Rex,' say Alice. 'I've say that in some book,
 but I don't think where.'
 
-'Well, it must be removed,' said the King very decidedly, and he called
+'Well, it must be take,' say the King very decidedly, and he call
 the Queen, who was loss at the mo, 'My dear! I bid you would
-get this cat removed!'
+get this cat take!'
 
-The Queen had only 1 way of settling all difficulties, great or small.
-'Off with his head!' she said, without yet looking round.
+The Queen had only 1 way of settling all difficulty, great or small.
+'Off with his head!' she say, without yet looking round.
 
-'I'll fetch the executioner myself,' said the King eagerly, and he
+'I'll fetch the executioner myself,' say the King eagerly, and he
 hurried off.
 
 Alice thought she might as well go back, and see how the biz was going
-on, as she heard the Queen's vox in the space, screaming with
-passion. She had already heard her doom 3 of the players to be
-executed for having missed their turns, and she did not ilk the look
+on, as she try the Queen's vox in the space, screaming with
+passion. She had already try her doom 3 of the player to be
+execute for get miss their turn, and she do not ilk the look
 of things at all, as the biz was in such mix-up that she never knew
-whether it was her turn or not. So she went in hunt of her hedgehog.
+whether it was her turn or not. So she go in hunt of her hedgehog.
 
-The hedgehog was meshed in a fight with another hedgehog, which seemed
-to Alice an splendid chance for croqueting 1 of them with the
-other: the only difficulty was, that her flamingo was gone across to the
-other side of the garden, where Alice could see it trying in a lost
+The hedgehog was wage in a fight with another hedgehog, which seem
+to Alice an splendid chance for croquet 1 of them with the
+other: the only difficulty was, that her flamingo was go across to the
+other side of the garden, where Alice could see it try in a lost
 sort of way to fly up into a tree.
 
-By the time she had caught the flamingo and brought it back, the fight
-was over, and both the hedgehogs were out of ken: 'but it doesn't
-thing much,' thought Alice, 'as all the arches ar gone from this side
-of the earth.' So she tucked it off under her arm, that it might not
-leak again, and went back for a small more conversation with her
+By the time she had get the flamingo and get it back, the fight
+was over, and both the hedgehog be out of ken: 'but it doesn't
+thing much,' thought Alice, 'as all the arc ar go from this side
+of the earth.' So she tuck it off under her arm, that it might not
+leak again, and go back for a small more conversation with her
 friend.
 
-When she got back to the Cheshire Cat, she was surprised to find quite a
+When she got back to the Cheshire Cat, she was surprise to find quite a
 big crew poised round it: there was a dispute going on 'tween
-the executioner, the King, and the Queen, who were all talking at once,
-while all the rest were quite still, and looked very uncomfortable.
+the executioner, the King, and the Queen, who be all talking at once,
+while all the rest be quite still, and look very uncomfortable.
 
-The mo Alice appeared, she was appealed to by all 3 to root
-the head, and they repeated their arguments to her, though, as they
+The mo Alice seem, she was appeal to by all 3 to root
+the head, and they echo their debate to her, though, as they
 all spoke at once, she found it very hard so to do out exactly
-what they said.
+what they say.
 
 The executioner's debate was, that you couldn't cut off a head unless
 there was a body to cut it off from: that he had never had to do such a
@@ -2192,20 +2192,20 @@ thing before, and he wasn't going to begin at HIS time of life.
 The King's debate was, that anything that had a head could be
 beheaded, and that you weren't to talk bunk.
 
-The Queen's debate was, that if something wasn't done most it in less
-than no time she'd get everybody executed, all round. (It was this last
-input that had made the unit party look so tomb and dying.)
+The Queen's debate was, that if something wasn't do most it in less
+than no time she'd get everybody execute, all round. (It was this last
+input that had do the unit party look so tomb and dying.)
 
-Alice could think of nil else to say but 'It belongs to the Duchess:
+Alice could think of nil else to say but 'It go to the Duchess:
 you'd best ask HER most it.'
 
-'She's in prison,' the Queen said to the executioner: 'fetch her here.'
-And the executioner went off ilk an arrow.
+'She's in prison,' the Queen say to the executioner: 'fetch her here.'
+And the executioner go off ilk an arrow.
 
- The Cat's head began fading off the mo he was gone, and,
+ The Cat's head began fading off the mo he was go, and,
 by the time he had come back with the Duchess, it had only
-disappeared; so the King and the executioner ran wildly up and down
-looking for it, while the rest of the party went back to the biz.
+vanish; so the King and the executioner go wildly up and down
+looking for it, while the rest of the party go back to the biz.
 
 
 
@@ -2213,585 +2213,585 @@ looking for it, while the rest of the party went back to the biz.
 CHAPTER IX. The Mock Turtle's Story
 
 'You can't think how glad I am to see you again, you dear old thing!'
-said the Duchess, as she tucked her arm affectionately into Alice's, and
-they walked off together.
+say the Duchess, as she tuck her arm affectionately into Alice's, and
+they walk off together.
 
 Alice was very glad to find her in such a pleasant mood, and thought
-to herself that perhaps it was only the pelt that had made her so
+to herself that perhaps it was only the pelt that had do her so
 blast when they met in the kitchen.
 
-'When I'M a Duchess,' she said to herself, (not in a very hopeful tone
-though), 'I won't get any pelt in my kitchen AT ALL. Soup does very
-well without--Maybe it's ever pelt that makes people hot-tempered,'
-she went on, very much pleased at having found out a new kind of
-rule, 'and acetum that makes them sour--and camomile that makes
-them bitter--and--and barley-sugar and such things that do children
+'When I'M a Duchess,' she say to herself, (not in a very hopeful tone
+though), 'I won't get any pelt in my kitchen AT ALL. Soup doe very
+well without--Maybe it's ever pelt that do people hot-tempered,'
+she go on, very much please at get found out a new kind of
+rule, 'and acetum that do them sour--and camomile that do
+them bitter--and--and barley-sugar and such things that do kid
 sweet-tempered. I only bid people knew that: so they wouldn't be so
 stingy most it, you know--'
 
-She had quite forgotten the Duchess by this time, and was a small
-startled when she heard her vox shut to her ear. 'You're thought
-most something, my dear, and that makes you bury to talk. I can't
+She had quite bury the Duchess by this time, and was a small
+jump when she try her vox shut to her ear. 'You're thought
+most something, my dear, and that do you bury to talk. I can't
 tell you just now what the moral of that is, but I shall think it in
 a bit.'
 
-'Perhaps it hasn't 1,' Alice ventured to input.
+'Perhaps it hasn't 1,' Alice stake to input.
 
-'Tut, tut, kid!' said the Duchess. 'Everything's got a moral, if only
-you can find it.' And she squeezed herself up closer to Alice's side as
+'Tut, tut, kid!' say the Duchess. 'Everything's got a moral, if only
+you can find it.' And she squeeze herself up closer to Alice's side as
 she spoke.
 
-Alice did not much ilk keeping so shut to her: 1st, because the
+Alice do not much ilk keeping so shut to her: 1st, because the
 Duchess was VERY ugly; and secondly, because she was exactly the
 flop height to rest her chin upon Alice's berm, and it was an
-uncomfortably tart chin. However, she did not ilk to be rude, so she
+uncomfortably tart chin. However, she do not ilk to be rude, so she
 bore it as well as she could.
 
-'The game's going on kinda best now,' she said, by way of keeping up
+'The game's going on kinda best now,' she say, by way of keeping up
 the conversation a small.
 
-''Tis so,' said the Duchess: 'and the moral of that is--"Oh, 'tis love,
-'tis love, that makes the man go round!"'
+''Tis so,' say the Duchess: 'and the moral of that is--"Oh, 'ti love,
+'ti love, that do the man go round!"'
 
-'Somebody said,' Alice whispered, 'that it's done by everybody minding
+'Somebody say,' Alice whisper, 'that it's do by everybody mind
 their own byplay!'
 
-'Ah, well! It way much the same thing,' said the Duchess, digging her
-tart small chin into Alice's berm as she added, 'and the moral
-of THAT is--"Take aid of the sense, and the sounds will take aid of
+'Ah, well! It way much the same thing,' say the Duchess, digging her
+tart small chin into Alice's berm as she add, 'and the moral
+of THAT is--"Take aid of the sense, and the go will take aid of
 themselves."'
 
 'How fond she is of finding morals in things!' Alice thought to herself.
 
-'I dare say you're wondering why I don't put my arm round your waist,'
-the Duchess said after a pause: 'the reason is, that I'm dubious most
+'I dare say you're wonder why I don't put my arm round your waist,'
+the Duchess say after a pause: 'the reason is, that I'm dubious most
 the mood of your flamingo. Shall I try the try out?'
 
 'HE might bite,' Alice carefully replied, not feeling at all dying to
-get the try out tried.
+get the try out try.
 
-'Very true,' said the Duchess: 'flamingoes and mustard both bite. And
+'Very true,' say the Duchess: 'flamingo and mustard both bite. And
 the moral of that is--"Birds of a plume fold together."'
 
 'Only mustard isn't a bird,' Alice remarked.
 
-'Right, as usual,' said the Duchess: 'what a top way you get of
+'Right, as usual,' say the Duchess: 'what a top way you get of
 putting things!'
 
-'It's a mineral, I THINK,' said Alice.
+'It's a mineral, I THINK,' say Alice.
 
-'Of row it is,' said the Duchess, who seemed ready to hold to
-everything that Alice said; 'there's a big mustard-mine near here. And
+'Of row it is,' say the Duchess, who seem ready to hold to
+everything that Alice say; 'there's a big mustard-mine near here. And
 the moral of that is--"The more there is of mine, the less there is of
 yours."'
 
-'Oh, I know!' exclaimed Alice, who had not attended to this last input,
+'Oh, I know!' cry Alice, who had not see to this last input,
 'it's a veg. It doesn't look ilk 1, but it is.'
 
-'I quite hold with you,' said the Duchess; 'and the moral of that
+'I quite hold with you,' say the Duchess; 'and the moral of that
 is--"Be what you would seem to be"--or if you'd ilk it put more
 simply--"Never ideate yourself not to be otherwise than what it might
-seem to others that what you were or might get been was not otherwise
-than what you had been would get appeared to them to be otherwise."'
+seem to others that what you be or might get be was not otherwise
+than what you had be would get seem to them to be otherwise."'
 
-'I think I should see that best,' Alice said very politely, 'if
-I had it written down: but I can't quite follow it as you say it.'
+'I think I should see that best,' Alice say very politely, 'if
+I had it pen down: but I can't quite follow it as you say it.'
 
-'That's nil to what I could say if I chose,' the Duchess replied, in
-a pleased tone.
+'That's nil to what I could say if I opt,' the Duchess replied, in
+a please tone.
 
-'Pray don't ail yourself to say it any longer than that,' said
+'Pray don't ail yourself to say it any longer than that,' say
 Alice.
 
-'Oh, don't talk most ail!' said the Duchess. 'I do you a pose
-of everything I've said as yet.'
+'Oh, don't talk most ail!' say the Duchess. 'I do you a pose
+of everything I've say as yet.'
 
 'A cheap sort of pose!' thought Alice. 'I'm glad they don't pay
-birthday presents ilk that!' But she did not stake to say it out
+birthday pose ilk that!' But she do not stake to say it out
 loud.
 
-'Thinking again?' the Duchess asked, with another dig of her tart
+'Thinking again?' the Duchess ask, with another dig of her tart
 small chin.
 
-'I've a flop to think,' said Alice sharp, for she was root to
-feel a small worried.
+'I've a flop to think,' say Alice sharp, for she was root to
+feel a small vex.
 
-'Just most as much flop,' said the Duchess, 'as pigs get to fly; and
+'Just most as much flop,' say the Duchess, 'as pig get to fly; and
 the m--'
 
-But here, to Alice's great surprise, the Duchess's vox died off, yet
+But here, to Alice's great surprise, the Duchess's vox go off, yet
 in the middle of her favourite word 'moral,' and the arm that was linked
-into hers began to shake. Alice looked up, and there stood the Queen
-in look of them, with her arms folded, frowning ilk a thunderstorm.
+into hers began to shake. Alice look up, and there stood the Queen
+in look of them, with her arms fold, lour ilk a thunderstorm.
 
 'A fine day, your Majesty!' the Duchess began in a low, weak vox.
 
-'Now, I pay you fair warning,' yelled the Queen, stamping on the
+'Now, I pay you fair warning,' cry the Queen, stamp on the
 earth as she spoke; 'either you or your head must be off, and that in
 most half no time! Take your pick!'
 
-The Duchess took her pick, and was gone in a mo.
+The Duchess took her pick, and was go in a mo.
 
-'Let's go on with the biz,' the Queen said to Alice; and Alice was
-too much scared to say a word, but slow followed her back to the
+'Let's go on with the biz,' the Queen say to Alice; and Alice was
+too much scare to say a word, but slow follow her back to the
 croquet-ground.
 
-The other guests had taken reward of the Queen's absence, and were
-resting in the tint: yet, the mo they saw her, they hurried
+The other guest had take reward of the Queen's absence, and be
+rest in the tint: yet, the mo they saw her, they hurried
 back to the biz, the Queen but remarking that a moment's hold would
-be them their lives.
+be them their life.
 
-All the time they were playing the Queen never left off quarrelling with
-the other players, and shouting 'Off with his head!' or 'Off with her
-head!' Those whom she sentenced were taken into custody by the soldiers,
-who of row had to lead off being arches to do this, so that by
-the end of half an hr or so there were no arches left, and all the
-players, except the King, the Queen, and Alice, were in custody and
+All the time they be playing the Queen never left off scrap with
+the other player, and shouting 'Off with his head!' or 'Off with her
+head!' Those whom she doom be take into custody by the soldier,
+who of row had to lead off being arc to do this, so that by
+the end of half an hr or so there be no arc left, and all the
+player, except the King, the Queen, and Alice, be in custody and
 under doom of execution.
 
-Then the Queen left off, quite out of breath, and said to Alice, 'Have
-you seen the Mock Turtle yet?'
+Then the Queen left off, quite out of breath, and say to Alice, 'Have
+you see the Mock Turtle yet?'
 
-'No,' said Alice. 'I don't yet know what a Mock Turtle is.'
+'No,' say Alice. 'I don't yet know what a Mock Turtle is.'
 
-'It's the thing Mock Turtle Soup is made from,' said the Queen.
+'It's the thing Mock Turtle Soup is do from,' say the Queen.
 
-'I never saw 1, or heard of 1,' said Alice.
+'I never saw 1, or try of 1,' say Alice.
 
-'Come on, so,' said the Queen, 'and he shall tell you his story,'
+'Come on, so,' say the Queen, 'and he shall tell you his story,'
 
-As they walked off together, Alice heard the King say in a low vox,
-to the troupe generally, 'You ar all pardoned.' 'Come, THAT'S a good
-thing!' she said to herself, for she had mat quite unhappy at the
-list of executions the Queen had ordered.
+As they walk off together, Alice try the King say in a low vox,
+to the troupe generally, 'You ar all pardon.' 'Come, THAT'S a good
+thing!' she say to herself, for she had mat quite unhappy at the
+list of execution the Queen had say.
 
 They very soon came upon a Gryphon, lying fast numb in the sun.
 (IF you don't know what a Gryphon is, look at the icon.) 'Up, lazy
-thing!' said the Queen, 'and take this young lady to see the Mock
+thing!' say the Queen, 'and take this young lady to see the Mock
 Turtle, and to try his story. I must go back and see after some
-executions I get ordered'; and she walked off, leaving Alice lone with
-the Gryphon. Alice did not quite ilk the look of the tool, but on
+execution I get say'; and she walk off, leaving Alice lone with
+the Gryphon. Alice do not quite ilk the look of the tool, but on
 the unit she thought it would be quite as safe to stay with it as to go
-after that blast Queen: so she waited.
+after that blast Queen: so she wait.
 
-The Gryphon sat up and rubbed its eyes: so it watched the Queen till
-she was out of ken: so it chuckled. 'What fun!' said the Gryphon,
+The Gryphon sat up and rub its eyes: so it see the Queen till
+she was out of ken: so it chuckle. 'What fun!' say the Gryphon,
 half to itself, half to Alice.
 
-'What IS the fun?' said Alice.
+'What IS the fun?' say Alice.
 
-'Why, SHE,' said the Gryphon. 'It's all her fancy, that: they never
-executes nobody, you know. Come on!'
+'Why, SHE,' say the Gryphon. 'It's all her fancy, that: they never
+execute nobody, you know. Come on!'
 
-'Everybody says "come on!" here,' thought Alice, as she went slow
-after it: 'I never was so ordered most in all my life, never!'
+'Everybody say "come on!" here,' thought Alice, as she go slow
+after it: 'I never was so say most in all my life, never!'
 
-They had not gone far before they saw the Mock Turtle in the space,
+They had not go far before they saw the Mock Turtle in the space,
 posing sad and lonely on a small ledge of rock, and, as they came
-nearer, Alice could try him sighing as if his pump would gap. She
-pitied him deep. 'What is his rue?' she asked the Gryphon, and the
-Gryphon answered, very nearly in the same words as before, 'It's all his
+near, Alice could try him sigh as if his pump would gap. She
+pitied him deep. 'What is his rue?' she ask the Gryphon, and the
+Gryphon reply, very nearly in the same words as before, 'It's all his
 fancy, that: he hasn't got no rue, you know. Come on!'
 
-So they went up to the Mock Turtle, who looked at them with big eyes
-full of tears, but said nil.
+So they go up to the Mock Turtle, who look at them with big eyes
+full of tears, but say nil.
 
-'This here young lady,' said the Gryphon, 'she wants for to know your
+'This here young lady,' say the Gryphon, 'she want for to know your
 story, she do.'
 
-'I'll tell it her,' said the Mock Turtle in a deep, hollow tone: 'sit
-down, both of you, and don't talk a word till I've ruined.'
+'I'll tell it her,' say the Mock Turtle in a deep, hollow tone: 'sit
+down, both of you, and don't talk a word till I've finish.'
 
 So they sat down, and nobody spoke for some minutes. Alice thought to
 herself, 'I don't see how he can EVEN goal, if he doesn't begin.' But
-she waited patiently.
+she wait patiently.
 
-'Once,' said the Mock Turtle at last, with a deep sigh, 'I was a real
+'Once,' say the Mock Turtle at last, with a deep sigh, 'I was a real
 Turtle.'
 
-These words were followed by a very long quiet, low only by an
+These words be follow by a very long quiet, low only by an
 occasional exclaiming of 'Hjckrrh!' from the Gryphon, and the constant
 heavy sobbing of the Mock Turtle. Alice was very nearly getting up and
-saying, 'Thank you, sir, for your interesting story,' but she could
-not aid thought there MUST be more to come, so she sat ease and said
+saying, 'Thank you, sir, for your interest story,' but she could
+not aid thought there MUST be more to come, so she sat ease and say
 nil.
 
-'When we were small,' the Mock Turtle went on at last, more calmly,
-though ease sobbing a small now and so, 'we went to shoal in the
-sea. The master was an old Turtle--we used to call him Tortoise--'
+'When we be small,' the Mock Turtle go on at last, more calmly,
+though ease sobbing a small now and so, 'we go to shoal in the
+sea. The master was an old Turtle--we use to call him Tortoise--'
 
-'Why did you call him Tortoise, if he wasn't 1?' Alice asked.
+'Why do you call him Tortoise, if he wasn't 1?' Alice ask.
 
-'We called him Tortoise because he taught us,' said the Mock Turtle
+'We call him Tortoise because he teach us,' say the Mock Turtle
 angrily: 'really you ar very dull!'
 
 'You ought to be ashamed of yourself for asking such a simple head,'
-added the Gryphon; and so they both sat still and looked at poor
-Alice, who mat ready to sink into the earth. At last the Gryphon said
+add the Gryphon; and so they both sat still and look at poor
+Alice, who mat ready to sink into the earth. At last the Gryphon say
 to the Mock Turtle, 'Drive on, old dude! Don't be all day most it!'
-and he went on in these words:
+and he go on in these words:
 
-'Yes, we went to shoal in the sea, though you mayn't trust it--'
+'Yes, we go to shoal in the sea, though you mayn't trust it--'
 
-'I never said I didn't!' interrupted Alice.
+'I never say I didn't!' break Alice.
 
-'You did,' said the Mock Turtle.
+'You do,' say the Mock Turtle.
 
-'Hold your knife!' added the Gryphon, before Alice could talk again.
-The Mock Turtle went on.
+'Hold your knife!' add the Gryphon, before Alice could talk again.
+The Mock Turtle go on.
 
-'We had the best of educations--in fact, we went to shoal every day--'
+'We had the best of educations--in fact, we go to shoal every day--'
 
-'I'VE been to a day-school, too,' said Alice; 'you needn't be so proud
+'I'VE be to a day-school, too,' say Alice; 'you needn't be so proud
 as all that.'
 
-'With extras?' asked the Mock Turtle a small uneasily.
+'With extra?' ask the Mock Turtle a small uneasily.
 
-'Yes,' said Alice, 'we learned French and music.'
+'Yes,' say Alice, 'we see French and music.'
 
-'And washing?' said the Mock Turtle.
+'And washing?' say the Mock Turtle.
 
-'Certainly not!' said Alice indignantly.
+'Certainly not!' say Alice indignantly.
 
-'Ah! so yours wasn't a really good shoal,' said the Mock Turtle in
+'Ah! so yours wasn't a really good shoal,' say the Mock Turtle in
 a tone of great ease. 'Now at OURS they had at the end of the bill,
 "French, music, AND WASHING--extra."'
 
-'You couldn't get wanted it much,' said Alice; 'living at the bottom of
+'You couldn't get want it much,' say Alice; 'living at the bottom of
 the sea.'
 
-'I couldn't open to see it.' said the Mock Turtle with a sigh. 'I
+'I couldn't open to see it.' say the Mock Turtle with a sigh. 'I
 only took the steady row.'
 
 'What was that?' inquired Alice.
 
 'Reeling and Writhing, of row, to begin with,' the Mock Turtle
-replied; 'and so the different branches of Arithmetic--Ambition,
+replied; 'and so the different arm of Arithmetic--Ambition,
 Distraction, Uglification, and Derision.'
 
-'I never heard of "Uglification,"' Alice ventured to say. 'What is it?'
+'I never try of "Uglification,"' Alice stake to say. 'What is it?'
 
-The Gryphon lifted up both its paws in surprise. 'What! Never heard of
-uglifying!' it exclaimed. 'You know what to beautify is, I say?'
+The Gryphon lift up both its paw in surprise. 'What! Never try of
+uglify!' it cry. 'You know what to beautify is, I say?'
 
-'Yes,' said Alice dubiously: 'it means--to--make--anything--prettier.'
+'Yes,' say Alice dubiously: 'it means--to--make--anything--prettier.'
 
-'Well, so,' the Gryphon went on, 'if you don't know what to uglify is,
+'Well, so,' the Gryphon go on, 'if you don't know what to uglify is,
 you ARE a simple.'
 
-Alice did not feel encouraged to ask any more questions most it, so she
-turned to the Mock Turtle, and said 'What else had you to see?'
+Alice do not feel encourage to ask any more head most it, so she
+turn to the Mock Turtle, and say 'What else had you to see?'
 
 'Well, there was Mystery,' the Mock Turtle replied, counting off
-the subjects on his flappers, '--Mystery, ancient and modern, with
+the case on his flapper, '--Mystery, ancient and modern, with
 Seaography: so Drawling--the Drawling-master was an old conger-eel,
-that used to come once a week: HE taught us Drawling, Stretching, and
+that use to come once a week: HE teach us Drawling, Stretching, and
 Fainting in Coils.'
 
-'What was THAT ilk?' said Alice.
+'What was THAT ilk?' say Alice.
 
-'Well, I can't show it you myself,' the Mock Turtle said: 'I'm too
-stiff. And the Gryphon never learnt it.'
+'Well, I can't show it you myself,' the Mock Turtle say: 'I'm too
+stiff. And the Gryphon never see it.'
 
-'Hadn't time,' said the Gryphon: 'I went to the Classics master, though.
+'Hadn't time,' say the Gryphon: 'I go to the Classics master, though.
 He was an old crab, HE was.'
 
-'I never went to him,' the Mock Turtle said with a sigh: 'he taught
-Laughing and Grief, they used to say.'
+'I never go to him,' the Mock Turtle say with a sigh: 'he teach
+Laughing and Grief, they use to say.'
 
-'So he did, so he did,' said the Gryphon, sighing in his turn; and both
-creatures hid their faces in their paws.
+'So he do, so he do,' say the Gryphon, sigh in his turn; and both
+tool hid their face in their paw.
 
-'And how many hours a day did you do lessons?' said Alice, in a hurry to
+'And how many hours a day do you do lesson?' say Alice, in a hurry to
 vary the case.
 
-'Ten hours the 1st day,' said the Mock Turtle: '9 the next, and so
+'Ten hours the 1st day,' say the Mock Turtle: '9 the next, and so
 on.'
 
-'What a odd plan!' exclaimed Alice.
+'What a odd plan!' cry Alice.
 
-'That's the reason they're called lessons,' the Gryphon remarked:
+'That's the reason they're call lesson,' the Gryphon remarked:
 'because they lessen from day to day.'
 
 This was quite a new idea to Alice, and she thought it over a small
-before she made her next input. 'Then the 11th day must get been a
+before she do her next input. 'Then the 11th day must get be a
 holiday?'
 
-'Of row it was,' said the Mock Turtle.
+'Of row it was,' say the Mock Turtle.
 
-'And how did you deal on the 12th?' Alice went on eagerly.
+'And how do you deal on the 12th?' Alice go on eagerly.
 
-'That's enough most lessons,' the Gryphon interrupted in a very decided
-tone: 'tell her something most the games now.'
+'That's enough most lesson,' the Gryphon break in a very decide
+tone: 'tell her something most the biz now.'
 
 
 
 
 CHAPTER X. The Lobster Quadrille
 
-The Mock Turtle sighed deep, and drew the back of 1 flapper across
-his eyes. He looked at Alice, and tried to talk, but for a min or
-2 sobs choked his vox. 'Same as if he had a os in his throat,'
-said the Gryphon: and it set to act quiver him and punching him in
-the back. At last the Mock Turtle recovered his vox, and, with tears
-running down his cheeks, he went on again:--
+The Mock Turtle sigh deep, and drew the back of 1 flapper across
+his eyes. He look at Alice, and try to talk, but for a min or
+2 sob gag his vox. 'Same as if he had a os in his throat,'
+say the Gryphon: and it set to act quiver him and plug him in
+the back. At last the Mock Turtle find his vox, and, with tears
+running down his cheek, he go on again:--
 
-'You may not get lived much under the sea--' ('I haven't,' said
-Alice)--'and perhaps you were never yet introduced to a lobster--'
-(Alice began to say 'I once tasted--' but checked herself hastily, and
-said 'No, never') '--so you can get no idea what a delicious thing a
+'You may not get live much under the sea--' ('I haven't,' say
+Alice)--'and perhaps you be never yet present to a lobster--'
+(Alice began to say 'I once taste--' but mark herself hastily, and
+say 'No, never') '--so you can get no idea what a delicious thing a
 Lobster Quadrille is!'
 
-'No, so,' said Alice. 'What sort of a dance is it?'
+'No, so,' say Alice. 'What sort of a dance is it?'
 
-'Why,' said the Gryphon, 'you 1st form into a line on the
+'Why,' say the Gryphon, 'you 1st form into a line on the
 sea-shore--'
 
-'Two lines!' cried the Mock Turtle. 'Seals, turtles, salmon, and so on;
-so, when you've cleared all the jelly-fish out of the way--'
+'Two line!' cry the Mock Turtle. 'Seals, turtle, salmon, and so on;
+so, when you've top all the jelly-fish out of the way--'
 
-'THAT generally takes some time,' interrupted the Gryphon.
+'THAT generally take some time,' break the Gryphon.
 
 '--you rise twice--'
 
-'Each with a lobster as a partner!' cried the Gryphon.
+'Each with a lobster as a partner!' cry the Gryphon.
 
-'Of row,' the Mock Turtle said: 'rise twice, set to partners--'
+'Of row,' the Mock Turtle say: 'rise twice, set to partner--'
 
-'--vary lobsters, and retire in same say,' continued the Gryphon.
+'--vary lobster, and retire in same say,' keep the Gryphon.
 
-'Then, you know,' the Mock Turtle went on, 'you flip the--'
+'Then, you know,' the Mock Turtle go on, 'you flip the--'
 
-'The lobsters!' yelled the Gryphon, with a bound into the air.
+'The lobster!' cry the Gryphon, with a bound into the air.
 
 '--as far out to sea as you can--'
 
-'Swim after them!' screamed the Gryphon.
+'Swim after them!' scream the Gryphon.
 
-'Turn a flip in the sea!' cried the Mock Turtle, capering wildly
+'Turn a flip in the sea!' cry the Mock Turtle, caper wildly
 most.
 
-'Change lobsters again!' yelled the Gryphon at the top of its vox.
+'Change lobster again!' yell the Gryphon at the top of its vox.
 
-'Back to land again, and that's all the 1st fig,' said the Mock
-Turtle, suddenly falling his vox; and the 2 creatures, who had been
+'Back to land again, and that's all the 1st fig,' say the Mock
+Turtle, suddenly drop his vox; and the 2 tool, who had be
 jumping most ilk mad things all this time, sat down again very sadly
-and quiet, and looked at Alice.
+and quiet, and look at Alice.
 
-'It must be a very pretty dance,' said Alice timidly.
+'It must be a very pretty dance,' say Alice timidly.
 
-'Would you ilk to see a small of it?' said the Mock Turtle.
+'Would you ilk to see a small of it?' say the Mock Turtle.
 
-'Very much so,' said Alice.
+'Very much so,' say Alice.
 
-'Come, let's try the 1st fig!' said the Mock Turtle to the Gryphon.
-'We can do without lobsters, you know. Which shall sing?'
+'Come, let's try the 1st fig!' say the Mock Turtle to the Gryphon.
+'We can do without lobster, you know. Which shall sing?'
 
-'Oh, YOU sing,' said the Gryphon. 'I've forgotten the words.'
+'Oh, YOU sing,' say the Gryphon. 'I've bury the words.'
 
 So they began solemnly dance round and round Alice, every now and
-so treading on her toes when they passed too shut, and waving their
-forepaws to mark the time, while the Mock Turtle sang this, very slow
+so tread on her toe when they pass too shut, and waving their
+forepaw to mark the time, while the Mock Turtle sang this, very slow
 and sadly:--
 
- '"Will you walk a small faster?" said a whiting to a snail.
- "There's a porpoise shut slow us, and he's treading on my tail.
+ '"Will you walk a small fast?" say a whiting to a snail.
+ "There's a porpoise shut slow us, and he's tread on my tail.
 
- See how eagerly the lobsters and the turtles all rise!
+ See how eagerly the lobster and the turtle all rise!
  They ar waiting on the shingle--will you come and join the dance?
 
  Will you, won't you, will you, won't you, will you join the dance?
  Will you, won't you, will you, won't you, won't you join the dance?
 
  "You can really get no whim how delicious it will be
- When they take us up and flip us, with the lobsters, out to sea!"
- But the snail replied "Too far, too far!" and gave a look askant--
- Said he thanked the whiting kindly, but he would not join the dance.
+ When they take us up and flip us, with the lobster, out to sea!"
+ But the snail replied "Too far, too far!" and pay a look askant--
+ Said he thank the whiting kindly, but he would not join the dance.
 
  Would not, could not, would not, could not, would not join the dance.
  Would not, could not, would not, could not, could not join the dance.
 
- '"What matters it how far we go?" his scaly friend replied.
+ '"What thing it how far we go?" his scaly friend replied.
  "There is another shore, you know, upon the other side.
- The further off from England the nearer is to France--
+ The further off from England the near is to France--
  Then turn not wan, dear snail, but come and join the dance.
 
  Will you, won't you, will you, won't you, will you join the dance?
  Will you, won't you, will you, won't you, won't you join the dance?"'
 
-'Thank you, it's a very interesting dance to see,' said Alice, feeling
+'Thank you, it's a very interest dance to see,' say Alice, feeling
 very glad that it was over at last: 'and I do so ilk that odd song
 most the whiting!'
 
-'Oh, as to the whiting,' said the Mock Turtle, 'they--you've seen them,
+'Oh, as to the whiting,' say the Mock Turtle, 'they--you've see them,
 of row?'
 
-'Yes,' said Alice, 'I've often seen them at dinn--' she checked herself
+'Yes,' say Alice, 'I've often see them at dinn--' she mark herself
 hastily.
 
-'I don't know where Dinn may be,' said the Mock Turtle, 'but if you've
-seen them so often, of row you know what they're ilk.'
+'I don't know where Dinn may be,' say the Mock Turtle, 'but if you've
+see them so often, of row you know what they're ilk.'
 
 'I trust so,' Alice replied thoughtfully. 'They get their tails in
-their mouths--and they're all over crumbs.'
+their mouths--and they're all over crumb.'
 
-'You're wrong most the crumbs,' said the Mock Turtle: 'crumbs would all
-wash off in the sea. But they HAVE their tails in their mouths; and the
-reason is--' here the Mock Turtle yawned and shut his eyes.--'Tell her
-most the reason and all that,' he said to the Gryphon.
+'You're wrong most the crumb,' say the Mock Turtle: 'crumb would all
+wash off in the sea. But they HAVE their tails in their mouth; and the
+reason is--' here the Mock Turtle yawn and shut his eyes.--'Tell her
+most the reason and all that,' he say to the Gryphon.
 
-'The reason is,' said the Gryphon, 'that they WOULD go with the lobsters
-to the dance. So they got thrown out to sea. So they had to pin a long
-way. So they got their tails fast in their mouths. So they couldn't get
+'The reason is,' say the Gryphon, 'that they WOULD go with the lobster
+to the dance. So they got flip out to sea. So they had to pin a long
+way. So they got their tails fast in their mouth. So they couldn't get
 them out again. That's all.'
 
-'Thank you,' said Alice, 'it's very interesting. I never knew so much
+'Thank you,' say Alice, 'it's very interest. I never knew so much
 most a whiting before.'
 
-'I can tell you more than that, if you ilk,' said the Gryphon. 'Do you
-know why it's called a whiting?'
+'I can tell you more than that, if you ilk,' say the Gryphon. 'Do you
+know why it's call a whiting?'
 
-'I never thought most it,' said Alice. 'Why?'
+'I never thought most it,' say Alice. 'Why?'
 
 'IT DOES THE BOOTS AND SHOES.' the Gryphon replied very solemnly.
 
-Alice was good puzzled. 'Does the boots and shoes!' she repeated
-in a wondering tone.
+Alice was good puzzle. 'Does the boot and shoes!' she echo
+in a wonder tone.
 
-'Why, what ar YOUR shoes done with?' said the Gryphon. 'I mean, what
-makes them so shiny?'
+'Why, what ar YOUR shoes do with?' say the Gryphon. 'I mean, what
+do them so shiny?'
 
-Alice looked down at them, and considered a small before she gave her
-reply. 'They're done with blacking, I trust.'
+Alice look down at them, and take a small before she pay her
+reply. 'They're do with blacking, I trust.'
 
-'Boots and shoes under the sea,' the Gryphon went on in a deep vox,
-'ar done with a whiting. Now you know.'
+'Boots and shoes under the sea,' the Gryphon go on in a deep vox,
+'ar do with a whiting. Now you know.'
 
-'And what ar they made of?' Alice asked in a tone of great wonder.
+'And what ar they do of?' Alice ask in a tone of great wonder.
 
-'Soles and eels, of row,' the Gryphon replied kinda impatiently:
+'Soles and eel, of row,' the Gryphon replied kinda impatiently:
 'any shrimp could get told you that.'
 
-'If I'd been the whiting,' said Alice, whose thoughts were ease running
-on the song, 'I'd get said to the porpoise, "Keep back, please: we
+'If I'd be the whiting,' say Alice, whose thought be ease running
+on the song, 'I'd get say to the porpoise, "Keep back, please: we
 don't want YOU with us!"'
 
-'They were obliged to get him with them,' the Mock Turtle said: 'no
+'They be bind to get him with them,' the Mock Turtle say: 'no
 wise fish would go anywhere without a porpoise.'
 
-'Wouldn't it really?' said Alice in a tone of great surprise.
+'Wouldn't it really?' say Alice in a tone of great surprise.
 
-'Of row not,' said the Mock Turtle: 'why, if a fish came to ME, and
+'Of row not,' say the Mock Turtle: 'why, if a fish came to ME, and
 told me he was going a journey, I should say "With what porpoise?"'
 
-'Don't you mean "aim"?' said Alice.
+'Don't you mean "aim"?' say Alice.
 
 'I mean what I say,' the Mock Turtle replied in an pained tone. And
-the Gryphon added 'Come, let's try some of YOUR adventures.'
+the Gryphon add 'Come, let's try some of YOUR escapade.'
 
-'I could tell you my adventures--beginning from this morn,' said
+'I could tell you my adventures--beginning from this morn,' say
 Alice a small timidly: 'but it's no use going back to yesterday,
 because I was a different soul so.'
 
-'Explain all that,' said the Mock Turtle.
+'Explain all that,' say the Mock Turtle.
 
-'No, no! The adventures 1st,' said the Gryphon in an raring tone:
-'explanations take such a dreadful time.'
+'No, no! The escapade 1st,' say the Gryphon in an raring tone:
+'account take such a dreadful time.'
 
-So Alice began telling them her adventures from the time when she 1st
+So Alice began telling them her escapade from the time when she 1st
 saw the White Rabbit. She was a small neural most it just at 1st,
-the 2 creatures got so shut to her, 1 on each side, and opened
-their eyes and mouths so VERY wide, but she gained courage as she went
-on. Her listeners were perfectly quiet till she got to the part most
+the 2 tool got so shut to her, 1 on each side, and open
+their eyes and mouth so VERY wide, but she win courage as she go
+on. Her listeners be perfectly quiet till she got to the part most
 her repeating 'YOU ARE OLD, FATHER WILLIAM,' to the cat, and the
 words all coming different, and so the Mock Turtle drew a long breath,
-and said 'That's very odd.'
+and say 'That's very odd.'
 
-'It's all most as odd as it can be,' said the Gryphon.
+'It's all most as odd as it can be,' say the Gryphon.
 
-'It all came different!' the Mock Turtle repeated thoughtfully. 'I
+'It all came different!' the Mock Turtle echo thoughtfully. 'I
 should ilk to try her try and echo something now. Tell her to
-begin.' He looked at the Gryphon as if he thought it had some kind of
+begin.' He look at the Gryphon as if he thought it had some kind of
 say-so over Alice.
 
-'Stand up and echo "'TIS THE VOICE OF THE SLUGGARD,"' said the
+'Stand up and echo "'TIS THE VOICE OF THE SLUGGARD,"' say the
 Gryphon.
 
-'How the creatures say 1 most, and do 1 echo lessons!'
+'How the tool say 1 most, and do 1 echo lesson!'
 thought Alice; 'I might as well be at shoal at once.' However, she
 got up, and began to echo it, but her head was so full of the Lobster
 Quadrille, that she hardly knew what she was saying, and the words came
 very queer so:--
 
-  ''Tis the vox of the Lobster; I heard him hold,
-  "You get baked me too brown, I must sugar my hair."
-  As a duck with its eyelids, so he with his nose
-  Trims his belt and his buttons, and turns out his toes.'
+  ''Tis the vox of the Lobster; I try him hold,
+  "You get bake me too brown, I must sugar my hair."
+  As a duck with its lid, so he with his nose
+  Trims his belt and his button, and turn out his toe.'
 
-       [later editions continued as follows
+       [later edition keep as follow
   When the sands ar all dry, he is gay as a lark,
-  And will talk in scornful tones of the Shark,
-  But, when the tide rises and sharks ar around,
+  And will talk in scornful tone of the Shark,
+  But, when the tide rise and shark ar around,
   His vox has a timid and tremulous go.]
 
-'That's different from what I used to say when I was a kid,' said the
+'That's different from what I use to say when I was a kid,' say the
 Gryphon.
 
-'Well, I never heard it before,' said the Mock Turtle; 'but it sounds
+'Well, I never try it before,' say the Mock Turtle; 'but it go
 uncommon bunk.'
 
-Alice said nil; she had sat down with her face in her hands,
-wondering if anything would EVER hap in a raw way again.
+Alice say nil; she had sat down with her face in her hands,
+wonder if anything would EVER hap in a raw way again.
 
-'I should ilk to get it explained,' said the Mock Turtle.
+'I should ilk to get it explain,' say the Mock Turtle.
 
-'She can't explain it,' said the Gryphon hastily. 'Go on with the next
+'She can't explain it,' say the Gryphon hastily. 'Go on with the next
 verse.'
 
-'But most his toes?' the Mock Turtle persisted. 'How COULD he turn them
+'But most his toe?' the Mock Turtle stay. 'How COULD he turn them
 out with his nose, you know?'
 
-'It's the 1st view in dance.' Alice said; but was awfully
-puzzled by the unit thing, and longed to vary the case.
+'It's the 1st view in dance.' Alice say; but was awfully
+puzzle by the unit thing, and longed to vary the case.
 
-'Go on with the next verse,' the Gryphon repeated impatiently: 'it
-begins "I passed by his garden."'
+'Go on with the next verse,' the Gryphon echo impatiently: 'it
+begin "I pass by his garden."'
 
-Alice did not dare to disobey, though she mat sure it would all come
-wrong, and she went on in a trembling vox:--
+Alice do not dare to disobey, though she mat sure it would all come
+wrong, and she go on in a trembling vox:--
 
-  'I passed by his garden, and marked, with 1 eye,
-  How the Owl and the Panther were sharing a pie--'
+  'I pass by his garden, and mark, with 1 eye,
+  How the Owl and the Panther be sharing a pie--'
 
-    [later editions continued as follows
+    [later edition keep as follow
   The Panther took pie-crust, and gravy, and meat,
   While the Owl had the dish as its part of the treat.
-  When the pie was all ruined, the Owl, as a boon,
-  Was kindly permitted to bag the spoon:
-  While the Panther received stab and fork with a growl,
-  And concluded the feast--]
+  When the pie was all finish, the Owl, as a boon,
+  Was kindly let to bag the spoon:
+  While the Panther get stab and fork with a growl,
+  And close the feast--]
 
 'What IS the use of repeating all that lug,' the Mock Turtle
-interrupted, 'if you don't explain it as you go on? It's by far the most
-puzzling thing I ever heard!'
+break, 'if you don't explain it as you go on? It's by far the most
+fox thing I ever try!'
 
-'Yes, I think you'd best lead off,' said the Gryphon: and Alice was
+'Yes, I think you'd best lead off,' say the Gryphon: and Alice was
 only too glad to do so.
 
-'Shall we try another fig of the Lobster Quadrille?' the Gryphon went
+'Shall we try another fig of the Lobster Quadrille?' the Gryphon go
 on. 'Or would you ilk the Mock Turtle to sing you a song?'
 
 'Oh, a song, please, if the Mock Turtle would be so kind,' Alice
-replied, so eagerly that the Gryphon said, in a kinda pained tone,
-'Hm! No accounting for tastes! Sing her "Turtle Soup," will you, old
+replied, so eagerly that the Gryphon say, in a kinda pained tone,
+'Hm! No accounting for taste! Sing her "Turtle Soup," will you, old
 dude?'
 
-The Mock Turtle sighed deep, and began, in a vox sometimes choked
-with sobs, to sing this:--
+The Mock Turtle sigh deep, and began, in a vox sometimes gag
+with sob, to sing this:--
 
    'Beautiful Soup, so rich and green,
    Waiting in a hot tureen!
-   Who for such dainties would not stoop?
+   Who for such goody would not stoop?
    Soup of the eve, beautiful Soup!
    Soup of the eve, beautiful Soup!
      Beau--ootiful Soo--oop!
@@ -2799,7 +2799,7 @@ with sobs, to sing this:--
    Soo--oop of the e--e--evening,
      Beautiful, beautiful Soup!
 
-   'Beautiful Soup! Who cares for fish,
+   'Beautiful Soup! Who aid for fish,
    Game, or any other dish?
    Who would not pay all else for 2
    Pennyworth only of beautiful Soup?
@@ -2809,16 +2809,16 @@ with sobs, to sing this:--
    Soo--oop of the e--e--evening,
      Beautiful, beauti--FUL SOUP!'
 
-'Chorus again!' cried the Gryphon, and the Mock Turtle had just begun
-to echo it, when a cry of 'The trial's root!' was heard in the
+'Chorus again!' cry the Gryphon, and the Mock Turtle had just begun
+to echo it, when a cry of 'The trial's root!' was try in the
 space.
 
-'Come on!' cried the Gryphon, and, taking Alice by the paw, it hurried
+'Come on!' cry the Gryphon, and, taking Alice by the paw, it hurried
 off, without waiting for the end of the song.
 
-'What test is it?' Alice panted as she ran; but the Gryphon only
-answered 'Come on!' and ran the faster, while more and more faintly
-came, carried on the air that followed them, the melancholy words:--
+'What test is it?' Alice pant as she go; but the Gryphon only
+reply 'Come on!' and go the fast, while more and more faintly
+came, run on the air that follow them, the melancholy words:--
 
    'Soo--oop of the e--e--evening,
      Beautiful, beautiful Soup!'
@@ -2828,256 +2828,256 @@ came, carried on the air that followed them, the melancholy words:--
 
 CHAPTER XI. Who Stole the Tarts?
 
-The King and Queen of Hearts were seated on their throne when they
-arrived, with a great crew assembled most them--all sorts of small
-birds and beasts, as well as the unit wad of cards: the Knave was
+The King and Queen of Hearts be sit on their throne when they
+get, with a great crew tack most them--all sort of small
+bird and wolf, as well as the unit wad of cards: the Knave was
 standing before them, in chains, with a soldier on each side to ward
 him; and near the King was the White Rabbit, with a trumpet in 1 paw,
 and a roll of lambskin in the other. In the very middle of the court
-was a table, with a big dish of tarts upon it: they looked so good,
-that it made Alice quite hungry to look at them--'I bid they'd get the
-test done,' she thought, 'and paw round the refreshments!' But there
-seemed to be no chance of this, so she began looking at everything most
+was a table, with a big dish of tart upon it: they look so good,
+that it do Alice quite hungry to look at them--'I bid they'd get the
+test do,' she thought, 'and paw round the recreation!' But there
+seem to be no chance of this, so she began looking at everything most
 her, to pass off the time.
 
-Alice had never been in a court of justice before, but she had say
-most them in books, and she was quite pleased to find that she knew
-the name of nearly everything there. 'That's the try,' she said to
+Alice had never be in a court of justice before, but she had say
+most them in book, and she was quite please to find that she knew
+the name of nearly everything there. 'That's the try,' she say to
 herself, 'because of his great wig.'
 
-The try, by the way, was the King; and as he wore his cap over the
-wig, (look at the frontispiece if you want to see how he did it,) he did
-not look at all easy, and it was certainly not comely.
+The try, by the way, was the King; and as he don his cap over the
+wig, (look at the frontispiece if you want to see how he do it,) he do
+not look at all easy, and it was certainly not go.
 
-'And that's the jury-box,' thought Alice, 'and those 12 creatures,'
-(she was obliged to say 'creatures,' you see, because some of them were
-animals, and some were birds,) 'I say they ar the jurors.' She said
+'And that's the jury-box,' thought Alice, 'and those 12 tool,'
+(she was bind to say 'tool,' you see, because some of them be
+beast, and some be bird,) 'I say they ar the juror.' She say
 this last word 2 or 3 times over to herself, being kinda proud of
-it: for she thought, and justly too, that very few small girls of her
-age knew the import of it at all. However, 'jury-men' would get done
+it: for she thought, and justly too, that very few small girl of her
+age knew the import of it at all. However, 'jury-men' would get do
 just as well.
 
-The 12 jurors were all writing very busily on slates. 'What ar they
-doing?' Alice whispered to the Gryphon. 'They can't get anything to put
+The 12 juror be all writing very busily on slate. 'What ar they
+do?' Alice whisper to the Gryphon. 'They can't get anything to put
 down yet, before the trial's begun.'
 
-'They're putting down their names,' the Gryphon whispered in reply, 'for
+'They're putting down their names,' the Gryphon whisper in reply, 'for
 awe they should bury them before the end of the test.'
 
-'Stupid things!' Alice began in a loud, incensed vox, but she stopped
-hastily, for the White Rabbit cried out, 'Silence in the court!' and the
-King put on his specs and looked uneasily round, to do out who
+'Stupid things!' Alice began in a loud, incensed vox, but she stop
+hastily, for the White Rabbit cry out, 'Silence in the court!' and the
+King put on his specs and look uneasily round, to do out who
 was talking.
 
-Alice could see, as well as if she were looking over their shoulders,
-that all the jurors were writing down 'dolt things!' on their slates,
+Alice could see, as well as if she be looking over their berm,
+that all the juror be writing down 'dolt things!' on their slate,
 and she could yet do out that 1 of them didn't know how to spell
 'dolt,' and that he had to ask his neighbour to tell him. 'A nice
 muddle their slates'll be in before the trial's over!' thought Alice.
 
-One of the jurors had a pencil that squeaked. This of row, Alice
-could not stand, and she went round the court and got slow him, and
-very soon found an chance of taking it off. She did it so apace
+One of the juror had a pencil that squeaked. This of row, Alice
+could not stand, and she go round the court and got slow him, and
+very soon found an chance of taking it off. She do it so apace
 that the poor small juror (it was Bill, the Lizard) could not do out
 at all what had go of it; so, after hunting all most for it, he was
-obliged to pen with 1 digit for the rest of the day; and this was
+bind to pen with 1 digit for the rest of the day; and this was
 of very small use, as it left no mark on the slate.
 
-'Herald, say the charge!' said the King.
+'Herald, say the charge!' say the King.
 
-On this the White Rabbit blew 3 blasts on the trumpet, and so
-unrolled the lambskin roll, and say as follows:--
+On this the White Rabbit blew 3 blast on the trumpet, and so
+unrolled the lambskin roll, and say as follow:--
 
-   'The Queen of Hearts, she made some tarts,
+   'The Queen of Hearts, she do some tart,
       All on a summer day:
-    The Knave of Hearts, he stole those tarts,
+    The Knave of Hearts, he stole those tart,
       And took them quite off!'
 
-'Consider your verdict,' the King said to the jury.
+'Consider your verdict,' the King say to the jury.
 
-'Not yet, not yet!' the Rabbit hastily interrupted. 'There's a great
+'Not yet, not yet!' the Rabbit hastily break. 'There's a great
 deal to come before that!'
 
-'Call the 1st see,' said the King; and the White Rabbit blew 3
-blasts on the trumpet, and called out, 'First see!'
+'Call the 1st see,' say the King; and the White Rabbit blew 3
+blast on the trumpet, and call out, 'First see!'
 
 The 1st see was the Hatter. He came in with a teacup in 1
 paw and a bit of bread-and-butter in the other. 'I beg pardon, your
-Majesty,' he began, 'for bringing these in: but I hadn't quite ruined
+Majesty,' he began, 'for bringing these in: but I hadn't quite finish
 my tea when I was sent for.'
 
-'You ought to get ruined,' said the King. 'When did you begin?'
+'You ought to get finish,' say the King. 'When do you begin?'
 
-The Hatter looked at the Mar Hare, who had followed him into the
+The Hatter look at the Mar Hare, who had follow him into the
 court, arm-in-arm with the Dormouse. 'Fourteenth of Mar, I think it
-was,' he said.
+was,' he say.
 
-'Fifteenth,' said the Mar Hare.
+'Fifteenth,' say the Mar Hare.
 
-'Sixteenth,' added the Dormouse.
+'Sixteenth,' add the Dormouse.
 
-'Write that down,' the King said to the jury, and the jury eagerly
-wrote down all 3 dates on their slates, and so added them up, and
-reduced the reply to shillings and pence.
+'Write that down,' the King say to the jury, and the jury eagerly
+pen down all 3 date on their slate, and so add them up, and
+cut the reply to shilling and cent.
 
-'Take off your hat,' the King said to the Hatter.
+'Take off your hat,' the King say to the Hatter.
 
-'It isn't mine,' said the Hatter.
+'It isn't mine,' say the Hatter.
 
-'Stolen!' the King exclaimed, turn to the jury, who instantly made a
+'Stolen!' the King cry, turn to the jury, who instantly do a
 memorandum of the fact.
 
-'I keep them to sell,' the Hatter added as an account; 'I've none of
+'I keep them to sell,' the Hatter add as an account; 'I've none of
 my own. I'm a hatter.'
 
-Here the Queen put on her specs, and began staring at the Hatter,
-who turned wan and fidgeted.
+Here the Queen put on her specs, and began stare at the Hatter,
+who turn wan and fidget.
 
-'Give your grounds,' said the King; 'and don't be neural, or I'll get
-you executed on the bit.'
+'Give your grounds,' say the King; 'and don't be neural, or I'll get
+you execute on the bit.'
 
-This did not seem to encourage the see at all: he kept shifty
+This do not seem to encourage the see at all: he kept shifty
 from 1 ft to the other, looking uneasily at the Queen, and in
 his mix-up he bit a big bit out of his teacup instead of the
 bread-and-butter.
 
-Just at this mo Alice mat a very odd esthesis, which puzzled
-her a good deal until she made out what it was: she was root to
+Just at this mo Alice mat a very odd esthesis, which puzzle
+her a good deal until she do out what it was: she was root to
 get larger again, and she thought at 1st she would get up and lead
-the court; but on s thoughts she decided to remain where she was as
+the court; but on s thought she decide to remain where she was as
 long as there was way for her.
 
-'I bid you wouldn't wring so.' said the Dormouse, who was posing
+'I bid you wouldn't wring so.' say the Dormouse, who was posing
 next to her. 'I can hardly breathe.'
 
-'I can't aid it,' said Alice very meekly: 'I'm growing.'
+'I can't aid it,' say Alice very meekly: 'I'm growing.'
 
-'You've no flop to get here,' said the Dormouse.
+'You've no flop to get here,' say the Dormouse.
 
-'Don't talk bunk,' said Alice more boldly: 'you know you're growing
+'Don't talk bunk,' say Alice more boldly: 'you know you're growing
 too.'
 
-'Yes, but I get at a sane pace,' said the Dormouse: 'not in that
-ridiculous forge.' And he got up very sulkily and crossed over to the
+'Yes, but I get at a sane pace,' say the Dormouse: 'not in that
+ridiculous forge.' And he got up very sulkily and span over to the
 other side of the court.
 
-All this time the Queen had never left off staring at the Hatter, and,
-just as the Dormouse crossed the court, she said to 1 of the officers
-of the court, 'Bring me the list of the singers in the last concert!' on
-which the wretched Hatter trembled so, that he shook both his shoes off.
+All this time the Queen had never left off stare at the Hatter, and,
+just as the Dormouse span the court, she say to 1 of the officer
+of the court, 'Bring me the list of the singer in the last concert!' on
+which the wretched Hatter tremble so, that he shook both his shoes off.
 
-'Give your grounds,' the King repeated angrily, 'or I'll get you
-executed, whether you're neural or not.'
+'Give your grounds,' the King echo angrily, 'or I'll get you
+execute, whether you're neural or not.'
 
 'I'm a poor man, your Majesty,' the Hatter began, in a trembling vox,
 '--and I hadn't begun my tea--not above a week or so--and what with the
 bread-and-butter getting so thin--and the twinkling of the tea--'
 
-'The twinkling of the what?' said the King.
+'The twinkling of the what?' say the King.
 
 'It began with the tea,' the Hatter replied.
 
-'Of row twinkling begins with a T!' said the King sharp. 'Do you
+'Of row twinkling begin with a T!' say the King sharp. 'Do you
 take me for a dunce? Go on!'
 
-'I'm a poor man,' the Hatter went on, 'and most things twinkled after
-that--only the Mar Hare said--'
+'I'm a poor man,' the Hatter go on, 'and most things winkle after
+that--only the Mar Hare say--'
 
-'I didn't!' the Mar Hare interrupted in a great hurry.
+'I didn't!' the Mar Hare break in a great hurry.
 
-'You did!' said the Hatter.
+'You do!' say the Hatter.
 
-'I deny it!' said the Mar Hare.
+'I deny it!' say the Mar Hare.
 
-'He denies it,' said the King: 'lead out that part.'
+'He deny it,' say the King: 'lead out that part.'
 
-'Well, at any rate, the Dormouse said--' the Hatter went on, looking
-uneasily round to see if he would deny it too: but the Dormouse denied
+'Well, at any rate, the Dormouse say--' the Hatter go on, looking
+uneasily round to see if he would deny it too: but the Dormouse deny
 nil, being fast numb.
 
-'After that,' continued the Hatter, 'I cut some more bread-and-butter--'
+'After that,' keep the Hatter, 'I cut some more bread-and-butter--'
 
-'But what did the Dormouse say?' 1 of the jury asked.
+'But what do the Dormouse say?' 1 of the jury ask.
 
-'That I can't think,' said the Hatter.
+'That I can't think,' say the Hatter.
 
-'You MUST think,' remarked the King, 'or I'll get you executed.'
+'You MUST think,' remarked the King, 'or I'll get you execute.'
 
-The wretched Hatter dropped his teacup and bread-and-butter, and went
+The wretched Hatter drop his teacup and bread-and-butter, and go
 down on 1 knee. 'I'm a poor man, your Majesty,' he began.
 
-'You're a very poor talker,' said the King.
+'You're a very poor talker,' say the King.
 
-Here 1 of the guinea-pigs cheered, and was now suppressed by
-the officers of the court. (As that is kinda a hard word, I will just
-explain to you how it was done. They had a big canvas bag, which tied
-up at the mouth with strings: into this they slipped the guinea-pig,
+Here 1 of the guinea-pigs urge, and was now curb by
+the officer of the court. (As that is kinda a hard word, I will just
+explain to you how it was do. They had a big canvas bag, which tie
+up at the mouth with strings: into this they slip the guinea-pig,
 head 1st, and so sat upon it.)
 
-'I'm glad I've seen that done,' thought Alice. 'I've so often say
-in the newspapers, at the end of trials, "There was some attempts
-at applause, which was now suppressed by the officers of the
-court," and I never understood what it meant till now.'
+'I'm glad I've see that do,' thought Alice. 'I've so often say
+in the paper, at the end of test, "There was some try
+at applause, which was now curb by the officer of the
+court," and I never see what it mean till now.'
 
-'If that's all you know most it, you may stand down,' continued the
+'If that's all you know most it, you may stand down,' keep the
 King.
 
-'I can't go no lour,' said the Hatter: 'I'm on the base, as it is.'
+'I can't go no lour,' say the Hatter: 'I'm on the base, as it is.'
 
 'Then you may SIT down,' the King replied.
 
-Here the other guinea-pig cheered, and was suppressed.
+Here the other guinea-pig urge, and was curb.
 
-'Come, that ruined the guinea-pigs!' thought Alice. 'Now we shall get
+'Come, that finish the guinea-pigs!' thought Alice. 'Now we shall get
 on best.'
 
-'I'd kinda goal my tea,' said the Hatter, with an dying look at the
-Queen, who was reading the list of singers.
+'I'd kinda goal my tea,' say the Hatter, with an dying look at the
+Queen, who was reading the list of singer.
 
-'You may go,' said the King, and the Hatter hastily left the court,
+'You may go,' say the King, and the Hatter hastily left the court,
 without yet waiting to put his shoes on.
 
-'--and just take his head off remote,' the Queen added to 1 of the
-officers: but the Hatter was out of ken before the officer could get
+'--and just take his head off remote,' the Queen add to 1 of the
+officer: but the Hatter was out of ken before the officer could get
 to the door.
 
-'Call the next see!' said the King.
+'Call the next see!' say the King.
 
-The next see was the Duchess's fix. She carried the pepper-box in
-her paw, and Alice guessed who it was, yet before she got into the
+The next see was the Duchess's fix. She run the pepper-box in
+her paw, and Alice guess who it was, yet before she got into the
 court, by the way the people near the door began sneezing all at once.
 
-'Give your grounds,' said the King.
+'Give your grounds,' say the King.
 
-'Shan't,' said the fix.
+'Shan't,' say the fix.
 
-The King looked uneasily at the White Rabbit, who said in a low vox,
+The King look uneasily at the White Rabbit, who say in a low vox,
 'Your Majesty must cross-examine THIS see.'
 
-'Well, if I must, I must,' the King said, with a melancholy air, and,
-after folding his arms and frowning at the fix till his eyes were
-nearly out of ken, he said in a deep vox, 'What ar tarts made of?'
+'Well, if I must, I must,' the King say, with a melancholy air, and,
+after folding his arms and lour at the fix till his eyes be
+nearly out of ken, he say in a deep vox, 'What ar tart do of?'
 
-'Pepper, mostly,' said the fix.
+'Pepper, mostly,' say the fix.
 
-'Treacle,' said a sleepy vox slow her.
+'Treacle,' say a sleepy vox slow her.
 
-'Collar that Dormouse,' the Queen shrieked out. 'Behead that Dormouse!
+'Collar that Dormouse,' the Queen pipe out. 'Behead that Dormouse!
 Turn that Dormouse out of court! Suppress him! Pinch him! Off with his
 whiskers!'
 
 For some minutes the unit court was in mix-up, getting the Dormouse
-turned out, and, by the time they had settled down again, the fix had
-disappeared.
+turn out, and, by the time they had root down again, the fix had
+vanish.
 
-'Never mind!' said the King, with an air of great ease. 'Call the next
-see.' And he added in an tinge to the Queen, 'Really, my dear,
-YOU must cross-examine the next see. It quite makes my forehead
+'Never mind!' say the King, with an air of great ease. 'Call the next
+see.' And he add in an tinge to the Queen, 'Really, my dear,
+YOU must cross-examine the next see. It quite do my forehead
 yen!'
 
-Alice watched the White Rabbit as he fumbled over the list, feeling very
+Alice see the White Rabbit as he fumble over the list, feeling very
 odd to see what the next see would be ilk, '--for they haven't
-got much grounds YET,' she said to herself. Imagine her surprise, when
+got much grounds YET,' she say to herself. Imagine her surprise, when
 the White Rabbit say out, at the top of his sharp small vox, the
 name 'Alice!'
 
@@ -3087,283 +3087,283 @@ name 'Alice!'
 CHAPTER XII. Alice's Evidence
 
 
-'Here!' cried Alice, quite forgetting in the flurry of the mo how
-big she had grown in the last few minutes, and she jumped up in such
-a hurry that she tipped over the jury-box with the edge of her skirt,
-upsetting all the jurymen on to the heads of the crew below, and there
-they lay rambling most, reminding her very much of a globe of goldfish
+'Here!' cry Alice, quite bury in the flurry of the mo how
+big she had get in the last few minutes, and she jump up in such
+a hurry that she tip over the jury-box with the edge of her skirt,
+upset all the jurymen on to the head of the crew below, and there
+they lay rambling most, remind her very much of a globe of goldfish
 she had accidentally upset the week before.
 
-'Oh, I BEG your pardon!' she exclaimed in a tone of great alarm, and
+'Oh, I BEG your pardon!' she cry in a tone of great alarm, and
 began pick them up again as apace as she could, for the stroke of
 the goldfish kept running in her head, and she had a vague sort of idea
 that they must be poised at once and put back into the jury-box, or
 they would go.
 
-'The test cannot go,' said the King in a very tomb vox, 'until
-all the jurymen ar back in their right places--ALL,' he repeated with
-great accent, looking hard at Alice as he said do.
+'The test cannot go,' say the King in a very tomb vox, 'until
+all the jurymen ar back in their right places--ALL,' he echo with
+great accent, looking hard at Alice as he say do.
 
-Alice looked at the jury-box, and saw that, in her rush, she had put
+Alice look at the jury-box, and saw that, in her rush, she had put
 the Lizard in head downwards, and the poor small thing was waving its
 tail most in a melancholy way, being quite unable to go. She soon got
-it out again, and put it flop; 'not that it signifies much,' she said
+it out again, and put it flop; 'not that it signify much,' she say
 to herself; 'I should think it would be QUITE as much use in the test
 1 way up as the other.'
 
-As soon as the jury had a small recovered from the blow of being
-upset, and their slates and pencils had been found and handed back to
+As soon as the jury had a small find from the blow of being
+upset, and their slate and pencil had be found and hand back to
 them, they set to act very diligently to pen out a story of the
-stroke, all except the Lizard, who seemed too much subdue to do
-anything but sit with its mouth open, gazing up into the roof of the
+stroke, all except the Lizard, who seem too much subdue to do
+anything but sit with its mouth open, gaze up into the roof of the
 court.
 
-'What do you know most this byplay?' the King said to Alice.
+'What do you know most this byplay?' the King say to Alice.
 
-'Nothing,' said Alice.
+'Nothing,' say Alice.
 
-'Nothing WHATEVER?' persisted the King.
+'Nothing WHATEVER?' stay the King.
 
-'Nothing whatever,' said Alice.
+'Nothing whatever,' say Alice.
 
-'That's very important,' the King said, turn to the jury. They were
-just root to pen this down on their slates, when the White Rabbit
-interrupted: 'UNimportant, your Majesty way, of row,' he said in a
-very respectful tone, but frowning and making faces at him as he spoke.
+'That's very important,' the King say, turn to the jury. They be
+just root to pen this down on their slate, when the White Rabbit
+break: 'UNimportant, your Majesty way, of row,' he say in a
+very respectful tone, but lour and making face at him as he spoke.
 
-'UNimportant, of row, I meant,' the King hastily said, and went on
+'UNimportant, of row, I mean,' the King hastily say, and go on
 to himself in an tinge,
 
-'important--unimportant--unimportant--important--' as if he were trying
-which word sounded best.
+'important--unimportant--unimportant--important--' as if he be try
+which word go best.
 
-Some of the jury wrote it down 'important,' and some 'unimportant.'
-Alice could see this, as she was near enough to look over their slates;
+Some of the jury pen it down 'important,' and some 'unimportant.'
+Alice could see this, as she was near enough to look over their slate;
 'but it doesn't thing a bit,' she thought to herself.
 
-At this mo the King, who had been for some time busily writing in
-his note-book, cackled out 'Silence!' and say out from his book, 'Rule
+At this mo the King, who had be for some time busily writing in
+his note-book, cackle out 'Silence!' and say out from his book, 'Rule
 Forty-two. ALL PERSONS MORE THAN A MILE HIGH TO LEAVE THE COURT.'
 
-Everybody looked at Alice.
+Everybody look at Alice.
 
-'I'M not a mi high,' said Alice.
+'I'M not a mi high,' say Alice.
 
-'You ar,' said the King.
+'You ar,' say the King.
 
-'Nearly 2 miles high,' added the Queen.
+'Nearly 2 mi high,' add the Queen.
 
-'Well, I shan't go, at any rate,' said Alice: 'too, that's not a
-steady rule: you invented it just now.'
+'Well, I shan't go, at any rate,' say Alice: 'too, that's not a
+steady rule: you forge it just now.'
 
-'It's the oldest rule in the book,' said the King.
+'It's the old rule in the book,' say the King.
 
-'Then it ought to be Number One,' said Alice.
+'Then it ought to be Number One,' say Alice.
 
-The King turned wan, and shut his note-book hastily. 'Consider your
-verdict,' he said to the jury, in a low, trembling vox.
+The King turn wan, and shut his note-book hastily. 'Consider your
+verdict,' he say to the jury, in a low, trembling vox.
 
-'There's more grounds to come yet, please your Majesty,' said the White
-Rabbit, jumping up in a great hurry; 'this paper has just been picked
+'There's more grounds to come yet, please your Majesty,' say the White
+Rabbit, jumping up in a great hurry; 'this paper has just be pick
 up.'
 
-'What's in it?' said the Queen.
+'What's in it?' say the Queen.
 
-'I haven't opened it yet,' said the White Rabbit, 'but it seems to be a
-letter, written by the captive to--to somebody.'
+'I haven't open it yet,' say the White Rabbit, 'but it seem to be a
+letter, pen by the captive to--to somebody.'
 
-'It must get been that,' said the King, 'unless it was written to
+'It must get be that,' say the King, 'unless it was pen to
 nobody, which isn't usual, you know.'
 
-'Who is it directed to?' said 1 of the jurymen.
+'Who is it direct to?' say 1 of the jurymen.
 
-'It isn't directed at all,' said the White Rabbit; 'in fact, there's
-nil written on the OUTSIDE.' He unfolded the paper as he spoke, and
-added 'It isn't a letter, after all: it's a set of verses.'
+'It isn't direct at all,' say the White Rabbit; 'in fact, there's
+nil pen on the OUTSIDE.' He open the paper as he spoke, and
+add 'It isn't a letter, after all: it's a set of verse.'
 
-'Are they in the prisoner's hand?' asked another of the jurymen.
+'Are they in the prisoner's hand?' ask another of the jurymen.
 
-'No, they're not,' said the White Rabbit, 'and that's the queerest thing
-most it.' (The jury all looked puzzled.)
+'No, they're not,' say the White Rabbit, 'and that's the queerest thing
+most it.' (The jury all look puzzle.)
 
-'He must get imitated somebody else's paw,' said the King. (The jury
-all brightened up again.)
+'He must get copy somebody else's paw,' say the King. (The jury
+all lighten up again.)
 
-'Please your Majesty,' said the Knave, 'I didn't pen it, and they
-can't show I did: there's no name signed at the end.'
+'Please your Majesty,' say the Knave, 'I didn't pen it, and they
+can't show I do: there's no name sign at the end.'
 
-'If you didn't sign it,' said the King, 'that only makes the thing
-worse. You MUST get meant some devilry, or else you'd get signed your
+'If you didn't sign it,' say the King, 'that only do the thing
+worse. You MUST get mean some devilry, or else you'd get sign your
 name ilk an fair man.'
 
 There was a general clapping of hands at this: it was the 1st really
-clever thing the King had said that day.
+clever thing the King had say that day.
 
-'That PROVES his guilt,' said the Queen.
+'That PROVES his guilt,' say the Queen.
 
-'It proves nil of the sort!' said Alice. 'Why, you don't yet know
+'It proves nil of the sort!' say Alice. 'Why, you don't yet know
 what they're most!'
 
-'Read them,' said the King.
+'Read them,' say the King.
 
 The White Rabbit put on his specs. 'Where shall I begin, please
-your Majesty?' he asked.
+your Majesty?' he ask.
 
-'Begin at the root,' the King said gravely, 'and go on till you
+'Begin at the root,' the King say gravely, 'and go on till you
 come to the end: so stop.'
 
-These were the verses the White Rabbit say:--
+These be the verse the White Rabbit say:--
 
-   'They told me you had been to her,
-    And mentioned me to him:
-   She gave me a good role,
-    But said I could not swim.
+   'They told me you had be to her,
+    And cite me to him:
+   She pay me a good role,
+    But say I could not swim.
 
-   He sent them word I had not gone
+   He sent them word I had not go
     (We know it to be true):
    If she should push the thing on,
     What would go of you?
 
-   I gave her 1, they gave him 2,
-    You gave us 3 or more;
-   They all returned from him to you,
-    Though they were mine before.
+   I pay her 1, they pay him 2,
+    You pay us 3 or more;
+   They all return from him to you,
+    Though they be mine before.
 
    If I or she should chance to be
     Involved in this amour,
-   He trusts to you to set them free,
-    Exactly as we were.
+   He rely to you to set them free,
+    Exactly as we be.
 
-   My whim was that you had been
+   My whim was that you had be
     (Before she had this go)
    An obstacle that came 'tween
     Him, and ourselves, and it.
 
-   Don't let him know she liked them best,
+   Don't let him know she like them best,
     For this must ever be
    A secret, kept from all the rest,
     Between yourself and me.'
 
-'That's the most important bit of grounds we've heard yet,' said the
+'That's the most important bit of grounds we've try yet,' say the
 King, rubbing his hands; 'so now let the jury--'
 
-'If any 1 of them can explain it,' said Alice, (she had grown so big
-in the last few minutes that she wasn't a bit afraid of interrupting
+'If any 1 of them can explain it,' say Alice, (she had get so big
+in the last few minutes that she wasn't a bit afraid of break
 him,) 'I'll pay him tanner. _I_ don't trust there's an atom of
 import in it.'
 
-The jury all wrote down on their slates, 'SHE doesn't trust there's an
+The jury all pen down on their slate, 'SHE doesn't trust there's an
 atom of import in it,' but none of them attempted to explain the paper.
 
-'If there's no import in it,' said the King, 'that saves a man of
+'If there's no import in it,' say the King, 'that save a man of
 ail, you know, as we needn't try to find any. And yet I don't know,'
-he went on, spreading out the verses on his knee, and looking at them
+he go on, spreading out the verse on his knee, and looking at them
 with 1 eye; 'I seem to see some import in them, after all. "--SAID
-I COULD NOT SWIM--" you can't swim, can you?' he added, turn to the
+I COULD NOT SWIM--" you can't swim, can you?' he add, turn to the
 Knave.
 
-The Knave shook his head sadly. 'Do I look ilk it?' he said. (Which he
-certainly did NOT, being made only of cardboard.)
+The Knave shook his head sadly. 'Do I look ilk it?' he say. (Which he
+certainly do NOT, being do only of cardboard.)
 
-'All flop, so far,' said the King, and he went on muttering over
-the verses to himself: '"WE KNOW IT TO BE TRUE--" that's the jury, of
+'All flop, so far,' say the King, and he go on muttering over
+the verse to himself: '"WE KNOW IT TO BE TRUE--" that's the jury, of
 row--"I GAVE HER ONE, THEY GAVE HIM TWO--" why, that must be what he
-did with the tarts, you know--'
+do with the tart, you know--'
 
-'But, it goes on "THEY ALL RETURNED FROM HIM TO YOU,"' said Alice.
+'But, it go on "THEY ALL RETURNED FROM HIM TO YOU,"' say Alice.
 
-'Why, there they ar!' said the King triumphantly, pointing to the tarts
-on the table. 'Nothing can be clearer than THAT. Then again--"BEFORE SHE
-HAD THIS FIT--" you never had fits, my dear, I think?' he said to the
+'Why, there they ar!' say the King triumphantly, point to the tart
+on the table. 'Nothing can be open than THAT. Then again--"BEFORE SHE
+HAD THIS FIT--" you never had go, my dear, I think?' he say to the
 Queen.
 
-'Never!' said the Queen furiously, throwing an inkstand at the Lizard
+'Never!' say the Queen furiously, flip an inkstand at the Lizard
 as she spoke. (The unfortunate small Bill had left off writing on his
-slate with 1 digit, as he found it made no mark; but he now hastily
-began again, using the ink, that was trickling down his face, as long as
-it lasted.)
+slate with 1 digit, as he found it do no mark; but he now hastily
+began again, using the ink, that was filter down his face, as long as
+it last.)
 
-'Then the words don't FIT you,' said the King, looking round the court
+'Then the words don't FIT you,' say the King, looking round the court
 with a grin. There was a dead quiet.
 
-'It's a pun!' the King added in an pained tone, and everybody laughed,
-'Let the jury take their verdict,' the King said, for most the
+'It's a pun!' the King add in an pained tone, and everybody laugh,
+'Let the jury take their verdict,' the King say, for most the
 20th time that day.
 
-'No, no!' said the Queen. 'Sentence first--verdict afterwards.'
+'No, no!' say the Queen. 'Sentence first--verdict afterwards.'
 
-'Stuff and bunk!' said Alice loud. 'The idea of having the
+'Stuff and bunk!' say Alice loud. 'The idea of get the
 doom 1st!'
 
-'Hold your knife!' said the Queen, turn purple.
+'Hold your knife!' say the Queen, turn purple.
 
-'I won't!' said Alice.
+'I won't!' say Alice.
 
-'Off with her head!' the Queen yelled at the top of her vox. Nobody
-moved.
+'Off with her head!' the Queen cry at the top of her vox. Nobody
+go.
 
-'Who cares for you?' said Alice, (she had grown to her full size by this
+'Who aid for you?' say Alice, (she had get to her full size by this
 time.) 'You're nil but a wad of cards!'
 
 At this the unit wad rose up into the air, and came fast down upon
-her: she gave a small scream, half of fright and half of ire, and
-tried to beat them off, and found herself lying on the bank, with her
+her: she pay a small scream, half of fright and half of ire, and
+try to beat them off, and found herself lying on the bank, with her
 head in the lap of her sis, who was gently brushing off some dead
-leaves that had fluttered down from the trees upon her face.
+leaf that had flutter down from the tree upon her face.
 
-'Wake up, Alice dear!' said her sis; 'Why, what a long nap you've
+'Wake up, Alice dear!' say her sis; 'Why, what a long nap you've
 had!'
 
-'Oh, I've had such a odd dream!' said Alice, and she told her
+'Oh, I've had such a odd dream!' say Alice, and she told her
 sis, as well as she could think them, all these strange Adventures
-of hers that you get just been reading most; and when she had
-ruined, her sis kissed her, and said, 'It WAS a odd dream,
+of hers that you get just be reading most; and when she had
+finish, her sis kiss her, and say, 'It WAS a odd dream,
 dear, certainly: but now go in to your tea; it's getting late.' So
-Alice got up and ran off, thought while she ran, as well she might,
-what a wonderful dream it had been.
+Alice got up and go off, thought while she go, as well she might,
+what a wonderful dream it had be.
 
 But her sis sat ease just as she left her, leaning her head on her
 paw, watching the scene sun, and thought of small Alice and all her
 wonderful Adventures, till she too began dreaming after a forge, and
 this was her dream:--
 
-First, she dreamed of small Alice herself, and once again the tiny
-hands were clasped upon her knee, and the vivid eager eyes were looking
-up into hers--she could try the very tones of her vox, and see that
+First, she dream of small Alice herself, and once again the tiny
+hands be clasp upon her knee, and the vivid eager eyes be looking
+up into hers--she could try the very tone of her vox, and see that
 queer small toss of her head to keep back the roving hair that
-WOULD ever get into her eyes--and ease as she listened, or seemed to
-hear, the unit put around her became live with the strange creatures
+WOULD ever get into her eyes--and ease as she hear, or seem to
+hear, the unit put around her go live with the strange tool
 of her small sister's dream.
 
-The long grass rustled at her feet as the White Rabbit hurried by--the
-scared Mouse splashed his way through the neighbouring pool--she
-could try the rale of the teacups as the Mar Hare and his friends
-shared their never-ending meal, and the sharp vox of the Queen
-order off her unfortunate guests to execution--once more the pig-baby
-was sneezing on the Duchess's knee, while plates and dishes crashed
+The long grass lift at her ft as the White Rabbit hurried by--the
+scare Mouse slosh his way through the neighbouring pool--she
+could try the rale of the teacup as the Mar Hare and his friend
+deal their never-ending meal, and the sharp vox of the Queen
+order off her unfortunate guest to execution--once more the pig-baby
+was sneezing on the Duchess's knee, while plate and dish ram
 around it--once more the pipe of the Gryphon, the squeaking of the
-Lizard's slate-pencil, and the choking of the suppressed guinea-pigs,
-filled the air, mixed up with the remote sobs of the wretched Mock
+Lizard's slate-pencil, and the choking of the curb guinea-pigs,
+fill the air, mix up with the remote sob of the wretched Mock
 Turtle.
 
-So she sat on, with shut eyes, and half believed herself in
+So she sat on, with shut eyes, and half trust herself in
 Wonderland, though she knew she had but to open them again, and all
 would vary to dull reality--the grass would be only rustling in the
 wind, and the pool rippling to the waving of the reeds--the rattling
-teacups would vary to tinkly sheep-bells, and the Queen's sharp
-cries to the vox of the shepherd boy--and the sneeze of the baby, the
-pipe of the Gryphon, and all the other queer noises, would vary (she
-knew) to the lost clamour of the busy farm-yard--while the lowing
+teacup would vary to tink sheep-bells, and the Queen's sharp
+cry to the vox of the shepherd boy--and the sneeze of the baby, the
+pipe of the Gryphon, and all the other queer noise, would vary (she
+knew) to the fox clamour of the busy farm-yard--while the lowing
 of the cows in the space would take the put of the Mock Turtle's
-heavy sobs.
+heavy sob.
 
-Lastly, she pictured to herself how this same small sis of hers
-would, in the after-time, be herself a grown woman; and how she would
-keep, through all her riper years, the simple and loving pump of her
-childhood: and how she would tuck most her other small children, and
+Lastly, she show to herself how this same small sis of hers
+would, in the after-time, be herself a get woman; and how she would
+keep, through all her ripe years, the simple and love pump of her
+childhood: and how she would tuck most her other small kid, and
 do THEIR eyes vivid and eager with many a strange tale, perhaps yet
 with the dream of Wonderland of long ago: and how she would feel with
-all their simple sorrows, and find a pleasure in all their simple joys,
+all their simple rue, and find a pleasure in all their simple joy,
 remembering her own child-life, and the happy summer days.
 
               THE END
@@ -3376,28 +3376,28 @@ End of Project Gutenberg's Alice's Adventures in Wonderland, by Lewis Carroll
 
 *** END OF THIS PROJECT GUTENBERG EBOOK ALICE'S ADVENTURES IN WONDERLAND ***
 
-***** This file should be named 11.txt or 11.zip *****
-This and all associated files of various formats will be found in:
+***** This file should be name 11.txt or 11.zip *****
+This and all link file of various format will be found in:
         http://www.gutenberg.org/1/11/
 
 
 
-Updated editions will replace the old one--the old editions
-will be renamed.
+Updated edition will replace the old one--the old edition
+will be rename.
 
-Creating the works from public land print editions way that no
-1 owns a United States copyright in these works, so the Foundation
+Creating the works from public land print edition way that no
+1 own a United States copyright in these works, so the Foundation
 (and you!) can copy and lot it in the United States without
-permission and without paying copyright royalties.  Special rules,
+permission and without pay copyright royalty.  Special rule,
 set forth in the General Terms of Use part of this permit, hold to
-copying and distributing Project Gutenberg-tm electronic works to
+copying and lot Project Gutenberg-tm electronic works to
 protect the PROJECT GUTENBERG-tm concept and trademark.  Project
-Gutenberg is a registered trademark, and may not be used if you
+Gutenberg is a register trademark, and may not be use if you
 bill for the eBooks, unless you get specific permission.  If you
-do not bill anything for copies of this eBook, complying with the
-rules is very easy.  You may use this eBook for nearly any aim
-such as creation of derivative works, reports, performances and
-search.  They may be modified and printed and given away--you may do
+do not bill anything for copy of this eBook, comply with the
+rule is very easy.  You may use this eBook for nearly any aim
+such as creation of derivative works, study, execution and
+search.  They may be modify and print and given away--you may do
 practically ANYTHING with public land eBooks.  Redistribution is
 case to the trademark permit, especially commercial
 redistribution.
@@ -3409,9 +3409,9 @@ redistribution.
 THE FULL PROJECT GUTENBERG LICENSE
 PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
 
-To protect the Project Gutenberg-tm charge of promoting the free
-dispersion of electronic works, by using or distributing this act
-(or any other act associated in any way with the phrase "Project
+To protect the Project Gutenberg-tm charge of boost the free
+dispersion of electronic works, by using or lot this act
+(or any other act link in any way with the phrase "Project
 Gutenberg"), you hold to comply with all the terms of the Full Project
 Gutenberg-tm License (usable with this file or online at
 http://gutenberg.org/license).
@@ -3425,134 +3425,134 @@ electronic act, you show that you get say, see, hold to
 and take all the terms of this permit and noetic prop
 (trademark/copyright) accord.  If you do not hold to abide by all
 the terms of this accord, you must cease using and take or ruin
-all copies of Project Gutenberg-tm electronic works in your ownership.
-If you paid a fee for obtaining a copy of or access to a Project
+all copy of Project Gutenberg-tm electronic works in your ownership.
+If you pay a fee for obtain a copy of or access to a Project
 Gutenberg-tm electronic act and you do not hold to be bound by the
 terms of this accord, you may obtain a repay from the soul or
-entity to whom you paid the fee as set forth in paragraph 1.E.8.
+entity to whom you pay the fee as set forth in paragraph 1.E.8.
 
-1.B.  "Project Gutenberg" is a registered trademark.  It may only be
-used on or associated in any way with an electronic act by people who
+1.B.  "Project Gutenberg" is a register trademark.  It may only be
+use on or link in any way with an electronic act by people who
 hold to be bound by the terms of this accord.  There ar a few
 things that you can do with most Project Gutenberg-tm electronic works
-yet without complying with the full terms of this accord.  See
+yet without comply with the full terms of this accord.  See
 paragraph 1.C below.  There ar a lot of things you can do with Project
 Gutenberg-tm electronic works if you follow the terms of this accord
 and aid keep free next access to Project Gutenberg-tm electronic
 works.  See paragraph 1.E below.
 
 1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
-or PGLAF), owns a digest copyright in the collection of Project
+or PGLAF), own a digest copyright in the collection of Project
 Gutenberg-tm electronic works.  Nearly all the single works in the
 collection ar in the public land in the United States.  If an
 single act is in the public land in the United States and you ar
 set in the United States, we do not take a flop to keep you from
-copying, distributing, performing, displaying or creating derivative
-works based on the act as long as all references to Project Gutenberg
-ar removed.  Of row, we hope that you will keep the Project
-Gutenberg-tm charge of promoting free access to electronic works by
+copying, lot, performing, display or make derivative
+works base on the act as long as all cite to Project Gutenberg
+ar take.  Of row, we hope that you will keep the Project
+Gutenberg-tm charge of boost free access to electronic works by
 freely sharing Project Gutenberg-tm works in compliance with the terms of
-this accord for keeping the Project Gutenberg-tm name associated with
+this accord for keeping the Project Gutenberg-tm name link with
 the act.  You can easy comply with the terms of this accord by
-keeping this act in the same format with its attached full Project
+keeping this act in the same format with its attach full Project
 Gutenberg-tm License when you part it without bill with others.
 
 1.D.  The copyright laws of the put where you ar set also rule
-what you can do with this act.  Copyright laws in most countries ar in
+what you can do with this act.  Copyright laws in most land ar in
 a constant say of vary.  If you ar remote the United States, tab
 the laws of your land in gain to the terms of this accord
-before downloading, copying, displaying, performing, distributing or
-creating derivative works based on this act or any other Project
-Gutenberg-tm act.  The Foundation makes no representations concerning
+before download, copying, display, performing, lot or
+make derivative works base on this act or any other Project
+Gutenberg-tm act.  The Foundation do no agency worry
 the copyright status of any act in any land remote the United
 States.
 
-1.E.  Unless you get removed all references to Project Gutenberg:
+1.E.  Unless you get take all cite to Project Gutenberg:
 
 1.E.1.  The next doom, with alive links to, or other quick
 access to, the full Project Gutenberg-tm License must seem prominently
 whenever any copy of a Project Gutenberg-tm act (any act on which the
-phrase "Project Gutenberg" appears, or with which the phrase "Project
-Gutenberg" is associated) is accessed, displayed, performed, viewed,
-copied or distributed:
+phrase "Project Gutenberg" seem, or with which the phrase "Project
+Gutenberg" is link) is access, display, do, view,
+copy or lot:
 
 This eBook is for the use of anyone anywhere at no be and with
-almost no restrictions whatsoever.  You may copy it, pay it off or
-re-use it under the terms of the Project Gutenberg License included
+almost no limitation whatsoever.  You may copy it, pay it off or
+re-use it under the terms of the Project Gutenberg License include
 with this eBook or online at www.gutenberg.org
 
-1.E.2.  If an single Project Gutenberg-tm electronic act is derived
-from the public land (does not take a mark indicating that it is
-posted with permission of the copyright holder), the act can be copied
-and distributed to anyone in the United States without paying any fees
-or charges.  If you ar redistributing or providing access to a act
-with the phrase "Project Gutenberg" associated with or appearing on the
-act, you must comply either with the requirements of paragraphs 1.E.1
+1.E.2.  If an single Project Gutenberg-tm electronic act is gain
+from the public land (doe not take a mark show that it is
+post with permission of the copyright holder), the act can be copy
+and lot to anyone in the United States without pay any fee
+or bill.  If you ar redistribute or ply access to a act
+with the phrase "Project Gutenberg" link with or appearing on the
+act, you must comply either with the demand of paragraph 1.E.1
 through 1.E.7 or obtain permission for the use of the act and the
-Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+Project Gutenberg-tm trademark as set forth in paragraph 1.E.8 or
 1.E.9.
 
-1.E.3.  If an single Project Gutenberg-tm electronic act is posted
+1.E.3.  If an single Project Gutenberg-tm electronic act is post
 with the permission of the copyright holder, your use and dispersion
-must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+must comply with both paragraph 1.E.1 through 1.E.7 and any additional
 terms imposed by the copyright holder.  Additional terms will be linked
-to the Project Gutenberg-tm License for all works posted with the
+to the Project Gutenberg-tm License for all works post with the
 permission of the copyright holder found at the root of this act.
 
 1.E.4.  Do not unlink or detach or take the full Project Gutenberg-tm
-License terms from this act, or any files containing a part of this
-act or any other act associated with Project Gutenberg-tm.
+License terms from this act, or any file take a part of this
+act or any other act link with Project Gutenberg-tm.
 
 1.E.5.  Do not copy, show, do, lot or redistribute this
 electronic act, or any part of this electronic act, without
-prominently displaying the doom set forth in paragraph 1.E.1 with
+prominently display the doom set forth in paragraph 1.E.1 with
 alive links or quick access to the full terms of the Project
 Gutenberg-tm License.
 
 1.E.6.  You may convert to and lot this act in any binary,
-flat, marked up, nonproprietary or proprietary form, including any
+flat, mark up, nonproprietary or proprietary form, include any
 word processing or hypertext form.  However, if you ply access to or
-lot copies of a Project Gutenberg-tm act in a format other than
-"Plain Vanilla ASCII" or other format used in the official version
-posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+lot copy of a Project Gutenberg-tm act in a format other than
+"Plain Vanilla ASCII" or other format use in the official version
+post on the official Project Gutenberg-tm web site (www.gutenberg.org),
 you must, at no additional be, fee or expense to the user, ply a
-copy, a way of exporting a copy, or a way of obtaining a copy upon
+copy, a way of exporting a copy, or a way of obtain a copy upon
 quest, of the act in its pilot "Plain Vanilla ASCII" or other
 form.  Any jump format must include the full Project Gutenberg-tm
-License as specified in paragraph 1.E.1.
+License as set in paragraph 1.E.1.
 
-1.E.7.  Do not bill a fee for access to, viewing, displaying,
-performing, copying or distributing any Project Gutenberg-tm works
+1.E.7.  Do not bill a fee for access to, viewing, display,
+performing, copying or lot any Project Gutenberg-tm works
 unless you comply with paragraph 1.E.8 or 1.E.9.
 
-1.E.8.  You may bill a sane fee for copies of or providing
-access to or distributing Project Gutenberg-tm electronic works provided
+1.E.8.  You may bill a sane fee for copy of or ply
+access to or lot Project Gutenberg-tm electronic works ply
 that
 
 - You pay a royalty fee of 20% of the 144 profits you gain from
-     the use of Project Gutenberg-tm works calculated using the method
-     you already use to aim your applicable taxes.  The fee is
-     owed to the owner of the Project Gutenberg-tm trademark, but he
-     has agreed to donate royalties under this paragraph to the
-     Project Gutenberg Literary Archive Foundation.  Royalty payments
-     must be paid within 60 days next each date on which you
+     the use of Project Gutenberg-tm works aim using the method
+     you already use to aim your applicable tax.  The fee is
+     owe to the owner of the Project Gutenberg-tm trademark, but he
+     has hold to donate royalty under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payment
+     must be pay within 60 days next each date on which you
      groom (or ar legally required to groom) your periodic tax
-     returns.  Royalty payments should be clear marked as such and
+     take.  Royalty payment should be clear mark as such and
      sent to the Project Gutenberg Literary Archive Foundation at the
-     call specified in Section 4, "Information most donations to
+     call set in Section 4, "Information most donations to
      the Project Gutenberg Literary Archive Foundation."
 
-- You ply a full repay of any money paid by a user who notifies
+- You ply a full repay of any money pay by a user who notifies
      you in writing (or by email) within 30 days of receipt that s/he
-     does not hold to the terms of the full Project Gutenberg-tm
+     doe not hold to the terms of the full Project Gutenberg-tm
      License.  You must require such a user to take or
-     ruin all copies of the works possessed in a physical medium
-     and stop all use of and all access to other copies of
+     ruin all copy of the works possess in a physical medium
+     and stop all use of and all access to other copy of
      Project Gutenberg-tm works.
 
 - You ply, in accordance with paragraph 1.F.3, a full repay of any
-     money paid for a act or a replacing copy, if a flaw in the
-     electronic act is discovered and reported to you within 90 days
+     money pay for a act or a replacing copy, if a flaw in the
+     electronic act is find and cover to you within 90 days
      of receipt of the act.
 
 - You comply with all other terms of this accord for free
@@ -3567,24 +3567,24 @@ Foundation as set forth in Section 3 below.
 
 1.F.
 
-1.F.1.  Project Gutenberg volunteers and employees expend considerable
+1.F.1.  Project Gutenberg offer and employee expend considerable
 sweat to key, do copyright search on, transcribe and proof
-public land works in creating the Project Gutenberg-tm
-collection.  Despite these efforts, Project Gutenberg-tm electronic
-works, and the medium on which they may be stored, may take
+public land works in make the Project Gutenberg-tm
+collection.  Despite these sweat, Project Gutenberg-tm electronic
+works, and the medium on which they may be store, may take
 "Defects," such as, but not limited to, incomplete, inaccurate or
-spoil data, written text errors, a copyright or other noetic
-prop infringement, a faulty or damaged disk or other medium, a
-computer virus, or computer codes that harm or cannot be say by
+spoil data, written text error, a copyright or other noetic
+prop infringement, a faulty or damage disk or other medium, a
+computer virus, or computer code that harm or cannot be say by
 your equipment.
 
 1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
-of Replacement or Refund" described in paragraph 1.F.3, the Project
+of Replacement or Refund" draw in paragraph 1.F.3, the Project
 Gutenberg Literary Archive Foundation, the owner of the Project
-Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm trademark, and any other party lot a Project
 Gutenberg-tm electronic act under this accord, disclaim all
-liability to you for amends, costs and expenses, including legal
-fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+liability to you for amends, costs and expense, include legal
+fee.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
 LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
 PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
 TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
@@ -3593,59 +3593,59 @@ INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
 DAMAGE.
 
 1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you find a
-flaw in this electronic act within 90 days of receiving it, you can
-get a repay of the money (if any) you paid for it by sending a
-written account to the soul you received the act from.  If you
-received the act on a physical medium, you must take the medium with
-your written account.  The soul or entity that provided you with
+flaw in this electronic act within 90 days of get it, you can
+get a repay of the money (if any) you pay for it by sending a
+pen account to the soul you get the act from.  If you
+get the act on a physical medium, you must take the medium with
+your pen account.  The soul or entity that ply you with
 the faulty act may elect to ply a replacing copy in lieu of a
-repay.  If you received the act electronically, the soul or entity
-providing it to you may opt to pay you a s chance to
+repay.  If you get the act electronically, the soul or entity
+ply it to you may opt to pay you a s chance to
 get the act electronically in lieu of a repay.  If the s copy
 is also faulty, you may exact a repay in writing without further
-opportunities to fix the job.
+chance to fix the job.
 
 1.F.4.  Except for the limited flop of replacing or repay set forth
-in paragraph 1.F.3, this act is provided to you 'AS-IS' WITH NO OTHER
+in paragraph 1.F.3, this act is ply to you 'AS-IS' WITH NO OTHER
 WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
 
-1.F.5.  Some states do not allow disclaimers of sure implied
-warranties or the exclusion or limitation of sure types of amends.
-If any disclaimer or limitation set forth in this accord violates the
+1.F.5.  Some say do not allow disclaimer of sure imply
+warranties or the exclusion or limitation of sure type of amends.
+If any disclaimer or limitation set forth in this accord break the
 law of the say applicable to this accord, the accord shall be
-taken to do the maximum disclaimer or limitation permitted by
+see to do the maximum disclaimer or limitation let by
 the applicable say law.  The invalidity or unenforceability of any
-supply of this accord shall not void the remaining provisions.
+supply of this accord shall not void the remain provisions.
 
 1.F.6.  INDEMNITY - You hold to indemnify and hold the Foundation, the
 trademark owner, any agent or employee of the Foundation, anyone
-providing copies of Project Gutenberg-tm electronic works in accordance
-with this accord, and any volunteers associated with the production,
+ply copy of Project Gutenberg-tm electronic works in accordance
+with this accord, and any offer link with the production,
 promotion and dispersion of Project Gutenberg-tm electronic works,
-harmless from all liability, costs and expenses, including legal fees,
+harmless from all liability, costs and expense, include legal fee,
 that rise flat or indirectly from any of the next which you do
 or do to come: (a) dispersion of this or any Project Gutenberg-tm
-act, (b) alteration, limiting, or additions or deletions to any
+act, (b) alteration, limiting, or gain or cut to any
 Project Gutenberg-tm act, and (c) any Defect you do.
 
 
 Section  2.  Information most the Mission of Project Gutenberg-tm
 
 Project Gutenberg-tm is synonymous with the free dispersion of
-electronic works in formats readable by the widest change of computers
-including obsolete, old, middle-aged and new computers.  It exists
-because of the efforts of hundreds of volunteers and donations from
-people in all walks of life.
+electronic works in format readable by the wide change of computer
+include obsolete, old, middle-aged and new computer.  It be
+because of the sweat of C of offer and donations from
+people in all walk of life.
 
-Volunteers and financial keep to ply volunteers with the
+Volunteers and financial keep to ply offer with the
 assistance they need, is vital to reaching Project Gutenberg-tm's
-goals and ensuring that the Project Gutenberg-tm collection will
-remain freely usable for generations to come.  In 2001, the Project
-Gutenberg Literary Archive Foundation was created to ply a secure
-and lasting next for Project Gutenberg-tm and next generations.
+end and ensuring that the Project Gutenberg-tm collection will
+remain freely usable for generation to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was make to ply a secure
+and lasting next for Project Gutenberg-tm and next generation.
 To see more most the Project Gutenberg Literary Archive Foundation
-and how your efforts and donations can aid, see Sections 3 and 4
+and how your sweat and donations can aid, see Sections 3 and 4
 and the Foundation web page at http://www.pglaf.org.
 
 
@@ -3653,17 +3653,17 @@ Section 3.  Information most the Project Gutenberg Literary Archive
 Foundation
 
 The Project Gutenberg Literary Archive Foundation is a non gain
-501(c)(3) educational corp organized under the laws of the
-say of MS and granted tax free status by the Internal
+501(c)(3) educational corp devise under the laws of the
+say of MS and give tax free status by the Internal
 Revenue Service.  The Foundation's EIN or federal tax identification
-list is 64-6221541.  Its 501(c)(3) letter is posted at
+list is 64-6221541.  Its 501(c)(3) letter is post at
 http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
 Literary Archive Foundation ar tax deductible to the full extent
-permitted by U.S. federal laws and your state's laws.
+let by U.S. federal laws and your state's laws.
 
 The Foundation's head power is set at 4557 Melan Dr. S.
-Fairbanks, AK, 99712., but its volunteers and employees ar scattered
-throughout legion locations.  Its byplay power is set at
+Fairbanks, AK, 99712., but its offer and employee ar dot
+throughout legion location.  Its byplay power is set at
 809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
 business@pglaf.org.  Email touch links and up to date touch
 info can be found at the Foundation's web site and official
@@ -3678,35 +3678,35 @@ For additional touch info:
 Section 4.  Information most Donations to the Project Gutenberg
 Literary Archive Foundation
 
-Project Gutenberg-tm depends upon and cannot go without wide
+Project Gutenberg-tm depend upon and cannot go without wide
 paste public keep and donations to run out its charge of
-increasing the list of public land and licensed works that can be
-freely distributed in machine readable form accessible by the widest
-array of equipment including outdated equipment.  Many small donations
-($1 to $5,000) ar specially important to maintaining tax free
+increase the list of public land and license works that can be
+freely lot in machine readable form accessible by the wide
+array of equipment include outdated equipment.  Many small donations
+($1 to $5,000) ar specially important to defend tax free
 status with the IRS.
 
-The Foundation is committed to complying with the laws regulating
-charities and kindly donations in all 50 states of the United
-States.  Compliance requirements ar not uniform and it takes a
-considerable sweat, much paperwork and many fees to see and keep up
-with these requirements.  We do not beg donations in locations
-where we get not received written check of compliance.  To
+The Foundation is send to comply with the laws regulating
+charity and kindly donations in all 50 say of the United
+States.  Compliance demand ar not uniform and it take a
+considerable sweat, much paperwork and many fee to see and keep up
+with these demand.  We do not beg donations in location
+where we get not get pen check of compliance.  To
 SEND DONATIONS or set the status of compliance for any
 special say see http://pglaf.org
 
-While we cannot and do not beg contributions from states where we
-get not met the appeal requirements, we know of no ban
-against accepting unsolicited donations from donors in such states who
-near us with offers to donate.
+While we cannot and do not beg part from say where we
+get not met the appeal demand, we know of no ban
+against take unsolicited donations from donor in such say who
+near us with bid to donate.
 
-International donations ar gratefully accepted, but we cannot do
-any statements concerning tax handling of donations received from
+International donations ar gratefully take, but we cannot do
+any statement worry tax handling of donations get from
 remote the United States.  U.S. laws lone swamp our small staff.
 
-Please tab the Project Gutenberg Web pages for stream donation
-methods and addresses.  Donations ar accepted in a list of other
-ways including checks, online payments and credit card donations.
+Please tab the Project Gutenberg Web page for stream donation
+method and call.  Donations ar take in a list of other
+ways include tab, online payment and credit card donations.
 To donate, please see: http://pglaf.org/donate
 
 
@@ -3714,14 +3714,14 @@ Section 5.  General Information About Project Gutenberg-tm electronic
 works.
 
 Professor Michael S. Hart is the conceiver of the Project Gutenberg-tm
-concept of a library of electronic works that could be freely shared
-with anyone.  For 30 years, he produced and distributed Project
+concept of a library of electronic works that could be freely deal
+with anyone.  For 30 years, he make and lot Project
 Gutenberg-tm eBooks with only a open web of offer keep.
 
 
-Project Gutenberg-tm eBooks ar often created from several printed
-editions, all of which ar confirmed as Public Domain in the U.S.
-unless a copyright mark is included.  Thus, we do not needfully
+Project Gutenberg-tm eBooks ar often make from several print
+edition, all of which ar affirm as Public Domain in the U.S.
+unless a copyright mark is include.  Thus, we do not needfully
 keep eBooks in compliance with any special paper edition.
 
 
@@ -3729,8 +3729,8 @@ Most people go at our Web site which has the main PG hunt facility:
 
      http://www.gutenberg.org
 
-This Web site includes info most Project Gutenberg-tm,
-including how to do donations to the Project Gutenberg Literary
+This Web site include info most Project Gutenberg-tm,
+include how to do donations to the Project Gutenberg Literary
 Archive Foundation, how to aid make our new eBooks, and how to
 take to our email newssheet to try most new eBooks.
 

--- a/parse.py
+++ b/parse.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import argparse
 import textwrap
 from nltk.corpus import wordnet as wn
 import nltk
@@ -11,7 +12,7 @@ def compressWord(word):
   sword = word
   synsets = wn.synsets(word)
 
-  for i, syn in enumerate(synsets):
+  for syn in synsets:
     syns = [n.name().replace('_', ' ') for n in syn.lemmas()]
 
     if not syns[0] in [word, wn.morphy(word)]:
@@ -21,22 +22,24 @@ def compressWord(word):
       if len(s) < leng:
         sword = s
         leng = len(sword)
+
   return sword
 
 def compressFile(filename):
-	out = open(filename).read() 
-	output = ""
+  text = open(filename).read() 
+  output = ""
 
-	words = nltk.tokenize.RegexpTokenizer("(?:[A-Z][.])+|\d[\d,.:\-/\d]*\d|\w+[\w\-\'.&|@:/]*\w+|\s|.|,|'|\"", False).tokenize(out)
-	for w in words:
-		if w:
-				c = compressWord(w)
-				if c == None:
-					output += w
-				else: 
-					output += c
+  words = nltk.tokenize.RegexpTokenizer("(?:[A-Z][.])+|\d[\d,.:\-/\d]*\d|\w+[\w\-\'.&|@:/]*\w+|\s|.|,|'|\"", False).tokenize(text)
+  for w in words:
+    c = compressWord(w)
+    output += c
 
-	return (output)
+  return output
 
 
-print (compressFile("pg11.txt"))
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='A lossy compression system for English Text')
+  parser.add_argument('file', help='The path to a file to compress')
+  args = parser.parse_args()
+
+  print(compressFile(args.file))

--- a/parse.py
+++ b/parse.py
@@ -7,20 +7,21 @@ import sys
 
 
 def compressWord(word):
-	leng = len(word)
-	sword = word
+  leng = len(word)
+  sword = word
+  synsets = wn.synsets(word)
 
-	for i, syn in enumerate(wn.synsets(word)):
-		syns = [n.name().replace('_', ' ') for n in syn.lemmas()]
+  for i, syn in enumerate(synsets):
+    syns = [n.name().replace('_', ' ') for n in syn.lemmas()]
 
-		if not syns[0] == word:
-			continue
+    if not syns[0] in [word, wn.morphy(word)]:
+      continue
 
-		for s in syns:
-			if len(s) < leng:
-				sword = s
-				leng = len(sword)
-	return sword
+    for s in syns:
+      if len(s) < leng:
+        sword = s
+        leng = len(sword)
+  return sword
 
 def compressFile(filename):
 	out = open(filename).read() 
@@ -28,11 +29,12 @@ def compressFile(filename):
 
 	words = nltk.tokenize.RegexpTokenizer("(?:[A-Z][.])+|\d[\d,.:\-/\d]*\d|\w+[\w\-\'.&|@:/]*\w+|\s|.|,|'|\"", False).tokenize(out)
 	for w in words:
-		c = compressWord(w)
-		if c == None:
-			output += w
-		else: 
-			output += c
+		if w:
+				c = compressWord(w)
+				if c == None:
+					output += w
+				else: 
+					output += c
 
 	return (output)
 


### PR DESCRIPTION
The previous code searched for synsets for an input word like 'pictures' or 'pulverised', which have suffixes like 's' and 'ed', The synset search of Wordnet automatically lemmatises the input to find matches like 'picture' and 'pulverise' (the altered forms not being stored in the dictionary), so these searches will produce results, but the code checking that the returned synset has the intended content doesn't allow such matches.

 Adding in `wn.morphy(word)` as an allowed match makes the matching more permissive and lets long plurals and past tenses be transformed. This results in better compression for the input text, though obviously also adds to the 'loss' because it permits shifts in tense.

I also tidied some of the code and added an interface so you can run it from the shell with different files. README and output are updated.
